### PR TITLE
new Pandunia words: enter, game, take, and more

### DIFF
--- a/concepts/E/eng-definition.tsv
+++ b/concepts/E/eng-definition.tsv
@@ -88,6 +88,7 @@ PLX:child-in-law.n	The spouse of someone's child.
 PLX:co-father-in-law.n	The father-in-law of ego’s child.
 PLX:co-mother-in-law.n	The mother-in-law of ego’s child.
 PLX:conlang.n.01	a human language that has been consciously devised by an individual or a group, as opposed to having naturally evolved as part of a culture like a natural language
+PLX:conlanger.n	someone who creates constructed languages
 PLX:daughter-in-law (of man).n	The daughter-in-law of a man.
 PLX:daughter-in-law (of woman).n	The daughter-in-law of a woman.
 PLX:day after tomorrow.adv	On the day following tomorrow.
@@ -143,6 +144,7 @@ PLX:like.pp	being similar or behaving similarly to the specified thing
 PLX:manioc bread.n	Bread made of the roots of the cassava plant.
 PLX:manioc flour.n	Flour made of the cassava plant or root.
 PLX:manioc juice.n	The manioc juice made of the cassava plant or root.
+PLX:may.v	have permission to do something
 PLX:men's house.n	A separate building for male persons.
 PLX:mochi.n	a small Japanese rice cake made from glutinous rice
 PLX:mother's brother.n	The brother of one's mother.
@@ -184,6 +186,7 @@ PLX:son-in-law (of woman).n	The son-in-law of a woman.
 PLX:stab to death.v	To kill by stabbing with a knife.
 PLX:step-.a	related by marriage
 PLX:swollen.a	Swollen.
+PLX:tectonic plate.n	a large piece of the earth's crust that participates in plate tectonics
 PLX:tennessine.n	Tennessine, the chemical element with atomic number 117 and symbol Ts.
 PLX:than.pp	in comparison to the specified thing
 PLX:thanks.int	Expression of gratitude.
@@ -1853,6 +1856,7 @@ PWN:cosmetic.n.01	a toiletry designed to beautify the body
 PWN:cosmic_time.n.01	the time covered by the physical formation and development of the universe
 PWN:cosmology.n.01	the metaphysical study of the origin and nature of the universe
 PWN:cosmology.n.02	the branch of astrophysics that studies the origin and evolution and structure of the universe
+PWN:cosmopolitan.s.03	of worldwide scope or applicability
 PWN:cost.n.01	the total spent for goods or services including money and time and labor
 PWN:cost.v.01	be priced at
 PWN:cost.v.02	require to lose, suffer, or sacrifice
@@ -2815,6 +2819,7 @@ PWN:fan.v.03	To blow air on (something) by means of a fan (hand-held, mechanical
 PWN:fanaticism.n.01	excessive intolerance of opposing views
 PWN:fanciful.s.02	not based on fact; unreal
 PWN:fancify.v.01	make more beautiful
+PWN:fantasy.n.02	the genre of fiction dealing with themes of magic and the supernatural
 PWN:far.a.01	located at a great distance in time or space or degree
 PWN:far.r.02	at or to or from a great distance in space
 PWN:faraway.s.01	Having a large intervening distance with regard to something.
@@ -3765,6 +3770,7 @@ PWN:inner.s.01	located inward; - Leonard Bernstein; - David Denby; - A.R.Gurney,
 PWN:inning.n.01	(baseball) one of nine divisions of play during which each team has a turn at bat
 PWN:innocent.a.01	Not guilty.
 PWN:innocent.a.01	free from evil or guilt
+PWN:input.n.04	a component of production; something that goes into the production of output
 PWN:inscription.n.01	letters inscribed (especially words engraved or carved) on something
 PWN:insect.n.01	A class of the Arthropoda typically having a segmented body with an external chitinous covering, a pair of compound eyes, a pair of antennae, three pairs of mouthparts, and two pairs of wings.
 PWN:inseminate.v.02	introduce semen into (a female)
@@ -3797,6 +3803,7 @@ PWN:intention.n.03	An anticipated outcome that is intended to obtain or that gui
 PWN:intentionally.r.01	(Doing or feeling something) in a deliberate or controlled way.
 PWN:interact.v.01	act together or towards others or with others
 PWN:interaction.n.01	a mutual or reciprocal action; interacting
+PWN:interactional.s.01	capable of being acted on or influenced by a human user
 PWN:interest.n.01	a sense of concern with and curiosity about someone or something
 PWN:interest.n.03	the power of attracting or holding one's attention (because it is unusual or exciting etc.)
 PWN:interest.n.06	(usually plural) a social group whose members control some field of activity and who have common aims
@@ -4164,6 +4171,7 @@ PWN:lineage.n.01	the descendants of one individual
 PWN:linear_unit.n.01	a unit of measurement of length
 PWN:linen.n.01	A material made from the fibers of the flax plant.
 PWN:linguist.n.02	a person who speaks more than one language
+PWN:linguistic.a.01	consisting of or rolated to language
 PWN:linguistic_relation.n.01	a relation between linguistic forms or constituents
 PWN:linguistics.n.01	the scientific study of language
 PWN:link.n.02	a fastener that serves to join or connect
@@ -4365,6 +4373,7 @@ PWN:mare.n.01	An adult female horse.
 PWN:marijuana.n.01	a strong-smelling plant from whose dried leaves a number of euphoriant and hallucinogenic drugs are prepared
 PWN:marital_status.n.01	the condition of being married or unmarried
 PWN:mark.n.01	a number or letter indicating quality (especially of a student's performance)
+PWN:mark.n.04	a visible indication made on a surface
 PWN:mark.n.06	a symbol of disgrace or infamy; --Genesis
 PWN:mark.n.10	a written or printed symbol (as for punctuation)
 PWN:mark.v.05	make or leave a mark on
@@ -4531,6 +4540,7 @@ PWN:mind.n.07	knowledge and intellectual ability
 PWN:mind.v.06	keep in mind
 PWN:mine.n.01	excavation in the earth from which ores and minerals are extracted
 PWN:mine.v.01	get from the earth by excavation
+PWN:miner.n.01	laborer who works in a mine
 PWN:mineral.n.01	solid homogeneous inorganic substances occurring in nature having a definite chemical composition
 PWN:minibike.n.01	small motorcycle with a low frame and small wheels and elevated handlebars
 PWN:minimize.v.01	make small or insignificant
@@ -4654,6 +4664,7 @@ PWN:multilingual.a.01	using or knowing more than one language
 PWN:multiply.v.01	combine by multiplication
 PWN:multitude.n.03	the common people generally
 PWN:mumble.v.01	To speak unintelligibly and without articulating.
+PWN:mundane.s.02	concerned with the world or worldly matters
 PWN:municipality.n.01	an urban district having corporate status and powers of self-government
 PWN:municipality.n.02	people living in a town or city having local self-government
 PWN:muntjac.n.01	Also known as barking deer, a kind of small deer of the genus Muntiacus.
@@ -5035,6 +5046,7 @@ PWN:parabola.n.01	a plane curve formed by the intersection of a right circular c
 PWN:parade.n.01	a ceremonial procession including people marching
 PWN:paradiddle.n.01	the sound of a drum (especially a snare drum) beaten rapidly and continuously
 PWN:parallel.a.01	being everywhere equidistant and not intersecting
+PWN:parameter.n.01	a constant in the equation of a curve that can be varied to yield a family of similar curves
 PWN:parasite.n.01	an animal or plant that lives in or on a host (another animal or plant); it obtains nourishment from the host without benefiting or killing the host
 PWN:parcel.n.02	the allotment of some amount by dividing something
 PWN:parch.v.01	cause to wither or parch from exposure to heat
@@ -5147,6 +5159,7 @@ PWN:periodical.n.01	a publication that appears at fixed intervals
 PWN:periphery.n.01	The border of an object.
 PWN:perjury.n.01	The deliberate giving of false or misleading testimony under oath.
 PWN:permanent.a.01	Lasting for an indefinitely long time
+PWN:permission.n.01	approval to do something
 PWN:permit.v.01	To give permission to an action.
 PWN:perpetrate.v.01	perform an act, usually with a negative connotation
 PWN:persecution.n.01	the act of persecuting (especially on the basis of race or religion)
@@ -6862,6 +6875,7 @@ PWN:tear.v.01	To pull at something in such a way that it ends up divided.
 PWN:tear.v.05	fill with tears or shed tears
 PWN:technetium.n.01	Technetium, the chemical element with atomic number 43 and symbol Tc.
 PWN:technology.n.01	the practical application of science to commerce or industry
+PWN:tectonics.n.02	the branch of geology studying the folding and faulting of the earth's crust
 PWN:teddy.n.01	plaything consisting of a child's toy bear (usually plush and stuffed with soft materials)
 PWN:teem.v.01	be teeming, be abuzz
 PWN:telecommunicate.v.01	communicate over long distances, as via the telephone or e-mail

--- a/data/id_map.tsv
+++ b/data/id_map.tsv
@@ -86,6 +86,7 @@ PLX:checkmate.int
 PLX:child-in-law.n		1060	2-6411		
 PLX:co-father-in-law.n			2-99903		
 PLX:co-mother-in-law.n			2-99904		
+PLX:conlanger.n					
 PLX:daughter-in-law (of man).n		2265	2-64		
 PLX:daughter-in-law (of woman).n		2264	2-641		
 PLX:day after tomorrow.adv		1179	14-481		
@@ -141,6 +142,7 @@ PLX:like.pp					177
 PLX:manioc bread.n		407	5-983		
 PLX:manioc flour.n		324	5-99909		
 PLX:manioc juice.n			5-99913		
+PLX:may.v					
 PLX:men's house.n		408	7-16		
 PLX:mochi.n			5-99914		
 PLX:mother's brother.n		2692	2-511		
@@ -181,6 +183,7 @@ PLX:son-in-law (of woman).n		2266	2-631
 PLX:stab to death.v		3189	9-223		
 PLX:step-.a			2-99902		
 PLX:swollen.a			4-99902		
+PLX:tectonic plate.n					
 PLX:tennessine.n					
 PLX:than.pp					180
 PLX:thanks.int			16-99903		
@@ -1850,6 +1853,7 @@ PWN:cosmetic.n.01	03113152-n
 PWN:cosmic_time.n.01	15116724-n				
 PWN:cosmology.n.01	06163223-n				
 PWN:cosmology.n.02	06098195-n				
+PWN:cosmopolitan.s.03	00527188-a				
 PWN:cost.n.01	13275847-n				
 PWN:cost.v.01	02702508-v				
 PWN:cost.v.02	02628961-v				
@@ -2346,6 +2350,7 @@ PWN:do.v.03	02561995-v
 PWN:do.v.11	02523221-v				
 PWN:doctor.n.01	10020890-n	597	4-87	Arzt::N	380
 PWN:doctrine.n.01	05943300-n				
+PWN:document.n.01	06470073-n				
 PWN:document.n.01	06470073-n				2254
 PWN:document.n.02	03217458-n				
 PWN:document.n.03	13403331-n				
@@ -2678,6 +2683,7 @@ PWN:exact.a.01	00914421-a
 PWN:examination.n.01	00635850-n				
 PWN:examination.n.02	07197021-n				
 PWN:examine.v.02	02131279-v				
+PWN:example.n.01	05820620-n				
 PWN:example.n.01	05820620-n				1972
 PWN:excavate.v.04	01310660-v				
 PWN:excavation.n.03	03302121-n				
@@ -2812,6 +2818,7 @@ PWN:fan.v.03	01885580-v	360	9-791
 PWN:fanaticism.n.01	06206334-n				
 PWN:fanciful.s.02	01936528-a				1953
 PWN:fancify.v.01	00293141-v				
+PWN:fantasy.n.02	06368425-n				
 PWN:far.a.01	00442361-a				
 PWN:far.r.02	00101051-r		12-44		2811
 PWN:faraway.s.01	00443274-a	1406		fern::A	
@@ -3764,6 +3771,7 @@ PWN:inner.s.01	00951831-s				2867
 PWN:inning.n.01	15255804-n				
 PWN:innocent.a.01	01319874-a				2110
 PWN:innocent.a.01	01319874-a	90	21-36		
+PWN:input.n.04	03573154-n				
 PWN:inscription.n.01	06405699-n				
 PWN:insect.n.01	02159955-n	620	3-81		905
 PWN:inseminate.v.02	00052548-v				
@@ -3796,6 +3804,7 @@ PWN:intention.n.03	00163233-n	1162	17-41
 PWN:intentionally.r.01	00062330-r	1031	17-99901		
 PWN:interact.v.01	02376958-v				
 PWN:interaction.n.01	00039021-n				
+PWN:interactional.s.01	01946439-a				
 PWN:interest.n.01	05682950-n				2022
 PWN:interest.n.03	05192451-n				
 PWN:interest.n.06	07968702-n				
@@ -4163,6 +4172,7 @@ PWN:lineage.n.01	08101937-n
 PWN:linear_unit.n.01	13603305-n				
 PWN:linen.n.01	03672521-n	916	6-23		
 PWN:linguist.n.02	10264219-n				
+PWN:linguistic.a.01	02842445-a				
 PWN:linguistic_relation.n.01	13797142-n				
 PWN:linguistics.n.01	06172789-n				
 PWN:link.n.02	03673971-n				
@@ -4365,6 +4375,7 @@ PWN:mare.n.01	02377480-n	938	3-44
 PWN:marijuana.n.01	12397210-n				1071
 PWN:marital_status.n.01	13963757-n				
 PWN:mark.n.01	05737153-n				
+PWN:mark.n.04	06798750-n				
 PWN:mark.n.06	06794666-n				
 PWN:mark.n.10	06817782-n				
 PWN:mark.v.05	00508032-v				
@@ -4531,6 +4542,8 @@ PWN:mind.n.07	05618849-n
 PWN:mind.v.06	00609506-v				
 PWN:mine.n.01	03768346-n				
 PWN:mine.v.01	01163620-v				
+PWN:miner.n.01	10319796-n				
+PWN:mineral.n.01	14662574-n				
 PWN:mineral.n.01	14662574-n				3335
 PWN:minibike.n.01	03769722-n				
 PWN:minimize.v.01	00427802-v				
@@ -4654,6 +4667,7 @@ PWN:multilingual.a.01	01545571-a
 PWN:multiply.v.01	00641672-v				2624
 PWN:multitude.n.03	08180190-n				
 PWN:mumble.v.01	01044533-v	128	18-16		
+PWN:mundane.s.02	02578035-a				
 PWN:municipality.n.01	08626283-n				
 PWN:municipality.n.02	08225581-n				
 PWN:muntjac.n.01	02434954-n	3152			
@@ -5035,6 +5049,7 @@ PWN:parabola.n.01	13886371-n
 PWN:parade.n.01	08428485-n				
 PWN:paradiddle.n.01	07388816-n				
 PWN:parallel.a.01	01718158-a				2960
+PWN:parameter.n.01	05859071-n				
 PWN:parasite.n.01	01384687-n				
 PWN:parcel.n.02	01085098-n				
 PWN:parch.v.01	00218330-v				
@@ -5147,6 +5162,7 @@ PWN:periodical.n.01	06593296-n
 PWN:periphery.n.01	13903576-n	2989		Rand::N	
 PWN:perjury.n.01	00772381-n	1792	21-47		
 PWN:permanent.a.01	01754421-a				3216
+PWN:permission.n.01	06689297-n				
 PWN:permit.v.01	00802318-v	1003	19-47		1671
 PWN:perpetrate.v.01	02582615-v				
 PWN:persecution.n.01	00420477-n				
@@ -6862,6 +6878,7 @@ PWN:tear.v.01	01573515-v	1735	9-28	zerreißen::V	3791
 PWN:tear.v.05	00066977-v				
 PWN:technetium.n.01	14657047-n				
 PWN:technology.n.01	00949619-n				3983
+PWN:tectonics.n.02	06118370-n				
 PWN:teddy.n.01	04399382-n				
 PWN:teem.v.01	02714974-v				
 PWN:telecommunicate.v.01	00790703-v				

--- a/data/id_map.tsv
+++ b/data/id_map.tsv
@@ -1783,7 +1783,6 @@ PWN:containerful.n.01	13756125-n
 PWN:contamination.n.03	00276987-n				
 PWN:contend.v.06	01090335-v	1423	20-11		782
 PWN:content.n.05	05809192-n				
-PWN:contest.n.01	07456188-n				
 PWN:contestant.n.01	09613191-n				
 PWN:context.n.02	14512817-n				
 PWN:continue.v.01	02684924-v	3699			3236

--- a/dict/E/eng.tsv
+++ b/dict/E/eng.tsv
@@ -4337,9 +4337,6 @@ PWN:contend.v.06		war
 PWN:content.n.05		cognitive content		
 PWN:content.n.05		content		
 PWN:content.n.05		mental object		
-PWN:contest.n.01		competition		
-PWN:contest.n.01		contest		
-PWN:contest.n.01		match		
 PWN:contestant.n.01		contestant		
 PWN:context.n.02		circumstance		
 PWN:context.n.02		context		
@@ -10639,6 +10636,7 @@ PWN:mat.n.01		mat		:maţţa
 PWN:match.n.01		friction match		
 PWN:match.n.01		lucifer		
 PWN:match.n.01		match		fra:mèche
+PWN:match.n.02		competition		
 PWN:match.n.02		contest		
 PWN:match.n.02		match		
 PWN:match.n.09		match		

--- a/dict/E/eng.tsv
+++ b/dict/E/eng.tsv
@@ -54,6 +54,7 @@ PLX:can.v		can
 PLX:can.v		know how		
 PLX:conlang.n.01		conlang		
 PLX:conlang.n.01		constructed language		
+PLX:conlanger.n		conlanger		
 PLX:daughter-in-law (of man).n		daughter-in-law		
 PLX:during.pp		during		
 PLX:during.pp		for the duration of		
@@ -94,6 +95,8 @@ PLX:instead of.pp		instead of
 PLX:kendo.n		kendo		
 PLX:kyudo.n		Oriental form of archery		
 PLX:kyudo.n		kyudo		
+PLX:may.v		be allowed to		
+PLX:may.v		may		
 PLX:mother-in-law (of man).n		mother-in-law		
 PLX:netbag.n		netbag		nhu:baggi
 PLX:nothing.pro		nothing		
@@ -120,8 +123,11 @@ PLX:someone.pro		somebody
 PLX:someone.pro		someone		
 PLX:son-in-law (of man).n		son-in-law		
 PLX:stab to death.v		stab		
+PLX:tectonic plate.n		tectonic plate		
 PLX:tennessine.n		tennessine		
+PLX:than.pp		as		
 PLX:than.pp		compared to		
+PLX:than.pp		like		
 PLX:than.pp		relative to		
 PLX:than.pp		than		
 PLX:thanks.int		thanks		
@@ -4333,6 +4339,7 @@ PWN:content.n.05		content
 PWN:content.n.05		mental object		
 PWN:contest.n.01		competition		
 PWN:contest.n.01		contest		
+PWN:contest.n.01		match		
 PWN:contestant.n.01		contestant		
 PWN:context.n.02		circumstance		
 PWN:context.n.02		context		
@@ -4500,6 +4507,10 @@ PWN:cosmology.n.01		cosmology
 PWN:cosmology.n.02		cosmogeny	
 PWN:cosmology.n.02		cosmogony	
 PWN:cosmology.n.02		cosmology	
+PWN:cosmopolitan.s.03		general		
+PWN:cosmopolitan.s.03		global		
+PWN:cosmopolitan.s.03		universal		
+PWN:cosmopolitan.s.03		worldwide		
 PWN:cost.n.01		cost		
 PWN:cost.v.01		be		
 PWN:cost.v.01		cost		
@@ -6948,6 +6959,8 @@ PWN:fancify.v.01		beautify
 PWN:fancify.v.01		embellish		
 PWN:fancify.v.01		fancify		
 PWN:fancify.v.01		prettify		
+PWN:fantasy.n.02		fantastical fiction		
+PWN:fantasy.n.02		fantasy		
 PWN:far.a.01		far		
 PWN:far.r.02		far		
 PWN:faraway.s.01		far-off		
@@ -8368,6 +8381,7 @@ PWN:happening.n.01		occurrent
 PWN:happiness.n.01		felicity		
 PWN:happiness.n.01		happiness		
 PWN:happiness.n.02		happiness		
+PWN:happiness.n.02		joy		
 PWN:happy.a.01		delighted		
 PWN:happy.a.01		glad		
 PWN:happy.a.01		happy		nhu:happ
@@ -9199,6 +9213,7 @@ PWN:inning.n.01		inning
 PWN:innocent.a.01		clean-handed		
 PWN:innocent.a.01		guiltless		
 PWN:innocent.a.01		innocent		:innocen-s, -tem
+PWN:input.n.04		input		
 PWN:inscription.n.01		inscription		
 PWN:inscription.n.01		lettering		
 PWN:insect.n.01		insect		:insectum
@@ -9270,6 +9285,7 @@ PWN:intentionally.r.01		on purpose
 PWN:intentionally.r.01		purposely		
 PWN:interact.v.01		interact		
 PWN:interaction.n.01		interaction		
+PWN:interactional.s.01		interactive		
 PWN:interest.n.01		interest		
 PWN:interest.n.01		involvement		
 PWN:interest.n.03		interest		
@@ -10076,6 +10092,7 @@ PWN:linear_unit.n.01		linear unit
 PWN:linen.n.01		linen		
 PWN:linguist.n.02		linguist		
 PWN:linguist.n.02		polyglot		
+PWN:linguistic.a.01		linguistic		
 PWN:linguistic_relation.n.01		linguistic relation		
 PWN:linguistics.n.01		linguistics		
 PWN:link.n.02		association		
@@ -10182,6 +10199,9 @@ PWN:load.v.02		load
 PWN:loan.n.01		loan		
 PWN:lobster.n.02		lobster		
 PWN:location.n.01		location		
+PWN:location.n.01		place		
+PWN:location.n.01		position		
+PWN:location.n.01		site		
 PWN:lock.n.01		lock		
 PWN:lock.n.04		lock		
 PWN:lock.n.04		lock chamber		
@@ -10539,6 +10559,7 @@ PWN:marital_status.n.01		marital status
 PWN:mark.n.01		grade		
 PWN:mark.n.01		mark		
 PWN:mark.n.01		score		
+PWN:mark.n.04		mark		
 PWN:mark.n.06		brand		
 PWN:mark.n.06		mark		
 PWN:mark.n.06		stain		
@@ -10926,6 +10947,7 @@ PWN:mind.v.06		bear in mind
 PWN:mind.v.06		mind		
 PWN:mine.n.01		mine		
 PWN:mine.v.01		mine		
+PWN:miner.n.01		miner		
 PWN:mineral.n.01		mineral		
 PWN:minibike.n.01		minibike		
 PWN:minibike.n.01		motorbike		
@@ -11202,6 +11224,8 @@ PWN:mumble.v.01		maunder
 PWN:mumble.v.01		mumble		
 PWN:mumble.v.01		mussitate		
 PWN:mumble.v.01		mutter		
+PWN:mundane.s.02		mundane		
+PWN:mundane.s.02		worldly		
 PWN:municipality.n.01		municipality		
 PWN:municipality.n.02		municipality		
 PWN:muntjac.n.01		barking deer		
@@ -12032,6 +12056,7 @@ PWN:paradiddle.n.01		drum roll
 PWN:paradiddle.n.01		paradiddle		
 PWN:paradiddle.n.01		roll		
 PWN:parallel.a.01		parallel		
+PWN:parameter.n.01		parameter		
 PWN:parasite.n.01		parasite		
 PWN:parcel.n.02		parcel		
 PWN:parcel.n.02		portion		
@@ -12279,6 +12304,9 @@ PWN:perjury.n.01		lying under oath
 PWN:perjury.n.01		perjury		:periūrium
 PWN:permanent.a.01		lasting		
 PWN:permanent.a.01		permanent		
+PWN:permission.n.01		licence		
+PWN:permission.n.01		license		
+PWN:permission.n.01		permission		
 PWN:permit.v.01		allow		:alouer
 PWN:permit.v.01		countenance		
 PWN:permit.v.01		let		
@@ -16339,6 +16367,7 @@ PWN:technetium.n.01		technology
 PWN:technology.n.01		engineering		
 PWN:technology.n.01		technetium		
 PWN:technology.n.01		technology		
+PWN:tectonics.n.02		plate tectonics		
 PWN:teddy.n.01		teddy		
 PWN:teddy.n.01		teddy bear		
 PWN:teem.v.01		pullulate		

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -451,7 +451,6 @@ PWN:construct.v.01		konstru	kon.stru
 PWN:construction.n.01 		bina	bina	
 PWN:container.n.01		kontener	kon.ten·er	
 PWN:contend.v.06		jang	jang	fas: جنگ (jang), hin:जंग (jang), ben:জঙ্গ (jôṅg), tur:cenk + zho:仗 (zhàng); 爭 (zhēng), yue:争 (zang1), kor:전쟁 (jeonjaeng), vie:(chiến) tranh + may:juang
-PWN:contest.n.01		mach	mach	eng:fra:match, rus:матч, tur:maç, jpn:マッチ
 PWN:continue.v.01		redura	re.dura	
 PWN:copper.n.01		kupre	kupr'e	eng:copper, fra:cuivre, spa:cobre, por:cobre, swa:kupri
 PWN:copy.n.02		kopi	kopi	eng:copy, fra:copie, spa:por:copia, rus:копия (kopiya), hin:कापी (kāpī), tur:kopya, may:kopi, zho:拷貝 (kǎobèi), jpn:コピー (kopī)
@@ -464,7 +463,7 @@ PWN:correct.a.01		koret	ko.ret
 PWN:correct.v.01		koretifa	koret·ifa	
 PWN:cosmology.n.01		kosmogenia	kosm·o·gen·ia	
 PWN:cosmology.n.02		kosmolojia	kosm·o·loj·ia	
-PWN:cosmopolitan.s.03		universal	univers·al	
+PWN:cosmopolitan.s.03		pandunian	pan·dun·ia·n	
 PWN:cotton.n.03		goton	goton	ara: قُطُن‎ (quṭun), spa:algodón, por:algodão, fra:coton, eng:cotton, may:katun, jpn:コットン (kotton), kor:코튼 (koteun) + hin:गुड (guḍ)
 PWN:coulomb.n.01		kulombe	kulomb'e	
 PWN:count.v.01		num	num	
@@ -624,7 +623,7 @@ PWN:enemy.n.01		inamik	in.am·ik
 PWN:energy.n.01		energia	energ·ia	eng:energy, spa:energía, por:energia, fra:énergie, rus:энергия (energiya), tur:enerji, fas:انرژی‎ (enerži), jpn:エネルギー (enerugī)
 PWN:engineer.n.01		enjener	enjen·er	eng:engineer, spa:ingeniero, por:engenheiro, rus:инженер (inzhener), hin:mar:इंजीनियर (iñjīniyar), jpn:エンジニア (enjinia), may:insinyur
 PWN:enough.r.01		bas	bas	spa:por:ita:basta + ara:fas:urd:س (bas), hin:(bas), swa:basi
-PWN:enter.v.01		entre	entr'e	eng:enter, por:spa:entrar, fra:entre, deu:eintreten
+PWN:enter.v.01		entra	en.tra	
 PWN:entertainment_industry.n.01 		shou biz	shou biz	
 PWN:environment.n.01		eko	eko	eng:spa:por:eco-, fra:éco-, deu:öko-, rus:эко-, tur:may:eko-, swa:iko-
 PWN:environmental.a.01		ekotik	eko·tik	
@@ -668,7 +667,7 @@ PWN:factory.n.01		fateria	fa·ter·ia
 PWN:fairy.n.01		pari	pari	fas: پری‎ (pari), hin:परी (parī), ben:পরী (pôri), may:tur:peri, hau:fari, eng:fairy; peri, fra:péri, deu:Peri, rus:пери (peri)
 PWN:family.n.02		famil	famil	deu:Familie, eng:family, spa:familia, por:família, fra:famille, fas: فامیل‎ (fâmil), swa:familia, may:famili
 PWN:fan.n.03		filer	fil·er	
-PWN:fantasy.n.02		fantazik	fantaz·ik	eng:fantasy, spa:fantástico, rus:фэ́нтези, swa:fantasia, jpn:ファンタジー
+PWN:fantasy.n.02		fantazia	fantaz·ia	eng:fantasy, spa:fantástico, rus:фэ́нтези, swa:fantasia, jpn:ファンタジー
 PWN:far.a.01		tele	tele	eng:spa:por:may:tele-, fra:télé-, rus:теле- (tele-)
 PWN:farmer.n.01		agrer	agr·er	
 PWN:fast.r.01		rapid	rap·id	
@@ -733,7 +732,7 @@ PWN:function.n.03		rol	rol	eng:role, fra:rôle, deu:Rolle, rus:роль (rol’)
 PWN:gadolinium.n.01		gadolinium	gadolin·ium	eng:gadolinium, fra:gadolinium, spa:gadolinio, por:gadolínio, rus:гадолиний, zho:钆 (gá), jpn:ガドリニウム, kor:가돌리늄, vie:gađolini, hin:ग्याडोलिनियम, ben:গ্যাডোলিনিয়াম, may:gadolinium, swa:gadolini, ara: جدولينيوم
 PWN:galaxy.n.03		galaxia	galax·ia	eng:galaxy, spa:galaxia, por:galáxia, fra:galaxie, rus:галактика (galaktika), tur:may:galaksi, hin:गैलेक्सी (gaileksī)
 PWN:gallium.n.01		galium	gal·ium	eng:gallium, fra:gallium, spa:galio, por:gálio, rus:галлий, zho:镓 (jiā), jpn:ガリウム, kor:갈륨, vie:gali, hin:गैलियम, ben:গ্যালিয়াম, may:galium, swa:gali, ara: جاليوم
-PWN:game.n.03		geim	geim	eng:game, jpn:ゲーム	
+PWN:game.n.03		jok	jok	fra:jeu, por:jogo, spa:juego + eng:joke, fas:جوک‎ (jok), jpn:ジョーク (jōku) + zho:笑话 (xiàohuà), nan:笑詼 (chhiò-khoe)
 PWN:garden.n.01		garde	gard'e	eng:garden, deu:Garten, fra:jardin, spa:jardín, por:jardim, rus:огород (ogorod), ara: جردة (jarda)
 PWN:garden.n.01		gardin	gard·in	
 PWN:garlic.n.01		lasun	lasun	hin:लहसुन (lahsun), ben:রসুন (rôśun) + zho:大蒜 (dàsuàn), yue:大蒜 (daai6 syun3), kor:대산 (daesan)
@@ -882,7 +881,7 @@ PWN:indium.n.01		hindium	hind·ium	eng:indium, fra:indium, spa:indium, por:índi
 PWN:indivisible.a.01		intomebil	in.tom·e·bil	
 PWN:inhumane.a.01	fig.	inhomanik	in.hom·an·ik	
 PWN:injury.n.01		trauma	trauma	eng:fra:may:trauma, deu:Trauma, spa:por:traumatismo, rus:травма (travma), tur:travma
-PWN:input.n.04		entret	entr·et	
+PWN:input.n.04		entrat	en·tra·t	
 PWN:insult.n.02		dusnim	dus.nim	
 PWN:intend.v.01		plan	plan	
 PWN:interact.v.01		konat	kon·at	
@@ -911,7 +910,7 @@ PWN:jew.n.01		yahud	yahud	heb: יְהוּדִי‎ (yehudí), ara: يَهُود�
 PWN:jihad.n.01		jihadisme	jihad·ism'e	
 PWN:jihad.n.02		jihad	jihad	
 PWN:jihadist.n.01		jihadiste	jihad·ist'e	
-PWN:joke.n.01		jok	jok	eng:fra:joke, fas:جوک‎ (jok), jpn:ジョーク (jōku) + zho:笑话 (xiàohuà), nan:笑詼 (chhiò-khoe)
+PWN:joke.n.01		jok kisa	jok kisa	
 PWN:journey.n.01		safar	safar	
 PWN:judaism.n.01		yahudisme	yahud·ism'e	
 PWN:judge.n.01		juder	jud·er	
@@ -1072,10 +1071,10 @@ PWN:military.a.01		jangik	jang·ik
 PWN:milk.n.01		milke	milk'e	eng:milk, deu:Milch, jpn:ミルク  (miruku), kor:밀크 (milkeu), lin:míliki, rus:молоко (moloko)
 PWN:mill.n.04		mol kan	mol kan	
 PWN:million.s.01		mega	mega	eng:fra:spa:por:may:tur:mega-, rus:мега- (mega-), jpn:メガ (mega), kor:메가- (mega-)
-PWN:mine.n.01		madineria	madin·er·ia	
-PWN:mine.v.01		teik madin	teik madin	
-PWN:miner.n.01		madiner	madin·er	
-PWN:mineral.n.01		madin	madin	ara:مَعْدِن, fas:معدن, tur:maden, swa:madini, ell:μαντέμι, eng:mine, por:spa:mina
+PWN:mine.n.01		mineria	min·er·ia	
+PWN:mine.v.01		mine	min'e	eng:fra:mine, deu:Mine, por:spa:mina + rus:минерал (mineral), tur:mineral, may:mineral + jpn:ミネラルウォーター (mineraru wōtā), hin:मिनरल वाटर (minral vāṭar)
+PWN:miner.n.01		miner	min·er	
+PWN:mineral.n.01		mineral	min·er·al	
 PWN:minimize.v.01		minimifa	min·im·ifa	
 PWN:minister.n.02		vazir	vazir	ara: وَزِير‎ (wazīr), fas: وَزیر‎ (vazir), hin:वज़ीर (vazīr), ben:উজির (ujir), tur:vezir, swa:may:wazir + eng:vizier, deu:Wesir, fra:por:vizir, spa:visir, rus:визирь (vizir')
 PWN:minor.s.10		minik	min·ik	
@@ -1193,7 +1192,7 @@ PWN:paintbrush.n.01		pente brosh	pent·e brosh
 PWN:palladium.n.01		paladium	palad·ium	eng:palladium, fra:palladium, spa:paladio, por:paládio, rus:палладий, zho:钯 (bǎ), jpn:パラジウム, kor:팔라듐, vie:palađi, hin:पलाडियम, ben:প্যালাডিয়াম, may:paladium, swa:paladi, ara: بلاديوم
 PWN:paper.n.01		kaguz	kaguz	zho:榖纸 (gǔzhǐ), yue:榖紙 (guk1zi2), jpn:榖紙 (kokushi), + fas:(kâğaz), hin:काग़ज़ (kāġaz), ben:কাগজ (kagôj), tur:kâğıt, ara:(kāḡid), kan:ಕಾಗದ (kāgada), tel:కాగితము (kāgitamu), tam:காகிதம் (kākitam), wol:keyit, uig:(qeghez)
 PWN:paper.n.01		karte	kart'e	ara: قِرْطَاس m (qirṭās), swa:karatasi, hau:takarda, may:kertas, khm:ក្រដាស (krɑdaah), tha:กระดาษ (kra-dat) + fra:carton, spa:cartón
-PWN:parameter.n.01		parametre	para·metr'e	eng:parameter, por:parâmetro, spa:parámetro, rus:пара́метр, jpn:パラメータ
+PWN:parameter.n.01		parametre	para.metr'e	
 PWN:parent.n.01		chin	chin	zho:親 (qīn), yue:親 (can), wuu:親 (qin), jpn:親 (shin), kor:친 (chin)
 PWN:park.n.01		parke	park'e	eng:deu:tur:pol:park, spa:por:parque, fra:parc, rus:парк (park), hin:पार्क (pārk)
 PWN:parrot.n.01		papagai	papagai	ara: بَبَغَاء‎ (babaḡāʾ), tur:papağan, deu:Papagei, spa:papagayo, por:papagaio, rus:попугай (popugay), jin:八哥 (bāgē)
@@ -1541,7 +1540,7 @@ PWN:t'ai_chi.n.01		tai gik kuen	tai·gik·kuen
 PWN:table.n.02		meza	meza	por:spa:mesa, hin:मेज़ (mez), swa:meza, may:meja, tam:மேசை (mesei), fas: میز‏‎ (miz), tur:masa
 PWN:table_knife.n.01		can dau	can dau	
 PWN:tae_kwon_do.n.01		taikuendao	tai·kuen·dao	
-PWN:take.v.04		teik	teik	eng:take
+PWN:take.v.04		tek	tek	eng:take
 PWN:talk.v.01		tok	tok	eng:talk, pcm:tok
 PWN:tall.a.01		gau	gau	zho:高 (gāo), yue:高 (gou1), wuu:高 (kau1), jpn:高 (kō), kor:고 (go), vie:cao
 PWN:tampon.n.01		tapon	tap·on	
@@ -1557,7 +1556,7 @@ PWN:teapot.n.01		cha pote	cha pot'e
 PWN:tear.n.01		ain sui	ain sui	tam:கண்ணீர் (kaṇṇīr), mal:കണ്ണുനീർ (kaṇṇunīr), tel:(kannīru), kor:눈물 (nunmul), vie:nước mắt, may:air mata, tha:น้ำตา
 PWN:technetium.n.01		tehnetium	tehn·et·ium	eng:technetium, fra:technétium, spa:tecnetio, por:tecnécio, rus:технеций, zho:锝 (dé), jpn:テクネチウム, kor:테크네튬, vie:tecnexi, hin:टेक्निशियम, ben:টেকনিসিয়াম, may:teknetium, swa:tekineti, ara: تكنيتيوم
 PWN:technology.n.01		teknolojia	tekn·o·loj·ia	
-PWN:tectonics.n.02		plate tektonik	plat'e tektonik	eng:tectonics, spa:tectónica, rus:текто́ника, tur:tektoniği, ara:التكتونية, hin:विवर्तनिकी, may:tektonik, jpn:テクトニクス
+PWN:tectonics.n.02		geoplatolojia	geo·plat·o·loj·ia	
 PWN:telephone.n.01		telefon	tele·fon	
 PWN:telescope.n.01		teleskope	tele·skop'e	
 PWN:television.n.01		televizion	tele·viz·ion	

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -32,6 +32,7 @@ PLX:bon voyage.int		sal safar	sal safar
 PLX:by means of.pp		be	be	eng:by, fas: به (be), ara: بِـ (bi-)
 PLX:can.v		kan	kan	eng:can, deu:können, zho:可 (kě), jpn:可 (ka), kor:가 (ga), vie:khả
 PLX:conlang.n.01		konstru bash	konstru bash	
+PLX:conlanger.n		bashkonstruer	bash·konstru·er	
 PLX:during.pp		dura·n	duran	
 PLX:everyone.pro		evri von	evri von	
 PLX:everything.pro		evri ting	evri ting	
@@ -49,6 +50,7 @@ PLX:if.cnj		if	if	eng:if
 PLX:instead of.pp		a plas of	a plas of	
 PLX:kendo.n		gemdao	gem·dao	
 PLX:kyudo.n		gung dao	gung dao	
+PLX:may.v		halal	halal	
 PLX:nothing.pro		no ting	no ting	
 PLX:oganesson.n		oganeson	oganeson	eng:fra:por:may:oganesson, spa:oganesón, rus:оганесон, jpn:オガネソン, kor:우누녹튬
 PLX:okay.n.01		okei	okei	
@@ -59,6 +61,7 @@ PLX:other.pro		altre	al·tr'e
 PLX:ramen.n		supa men	supa men	
 PLX:should.v		shud	shud	eng:should
 PLX:someone.pro		som von	som von	
+PLX:tectonic plate.n		geo plate	geo plat'e	
 PLX:tennessine.n		tenesium	tenes·ium	eng:fra:por:may:tennessine, spa:teneso, rus:теннессин, jpn:テネシン, kor:우눈셉튬
 PLX:than.pp		dan	dan	eng:than, deu:denn, ned:dan, tur:-dan; -den
 PLX:thanks.int		danke	dank'e	
@@ -448,6 +451,7 @@ PWN:construct.v.01		konstru	kon.stru
 PWN:construction.n.01 		bina	bina	
 PWN:container.n.01		kontener	kon.ten·er	
 PWN:contend.v.06		jang	jang	fas: جنگ (jang), hin:जंग (jang), ben:জঙ্গ (jôṅg), tur:cenk + zho:仗 (zhàng); 爭 (zhēng), yue:争 (zang1), kor:전쟁 (jeonjaeng), vie:(chiến) tranh + may:juang
+PWN:contest.n.01		mach	mach	eng:fra:match, rus:матч, tur:maç, jpn:マッチ
 PWN:continue.v.01		redura	re.dura	
 PWN:copper.n.01		kupre	kupr'e	eng:copper, fra:cuivre, spa:cobre, por:cobre, swa:kupri
 PWN:copy.n.02		kopi	kopi	eng:copy, fra:copie, spa:por:copia, rus:копия (kopiya), hin:कापी (kāpī), tur:kopya, may:kopi, zho:拷貝 (kǎobèi), jpn:コピー (kopī)
@@ -460,6 +464,7 @@ PWN:correct.a.01		koret	ko.ret
 PWN:correct.v.01		koretifa	koret·ifa	
 PWN:cosmology.n.01		kosmogenia	kosm·o·gen·ia	
 PWN:cosmology.n.02		kosmolojia	kosm·o·loj·ia	
+PWN:cosmopolitan.s.03		universal	univers·al	
 PWN:cotton.n.03		goton	goton	ara: قُطُن‎ (quṭun), spa:algodón, por:algodão, fra:coton, eng:cotton, may:katun, jpn:コットン (kotton), kor:코튼 (koteun) + hin:गुड (guḍ)
 PWN:coulomb.n.01		kulombe	kulomb'e	
 PWN:count.v.01		num	num	
@@ -552,6 +557,7 @@ PWN:divine.v.01		mante	mant’e
 PWN:doctor.n.01		dokter	dokt·er	eng:spa:doctor, fra:docteur, por:doutor, deu:tur:doktor, rus:доктор (doktor), fas:دکتر‎ (doktor), hin:डॉक्टर (ḍŏkṭar), may:dokter, ara: دُكْتُور‎ (duktūr), ful:doktoor, swa:dokta
 PWN:doctor.n.01		medik dokter	med·ik dokt·er	
 PWN:doctrine.n.01		isme	ism'e	eng:-ism, deu:ismus, fra:-isme, spa:por:-ismo, rus:-изм (-izm), may:-isme
+PWN:document.n.01		dokumen	dokumen	eng:document, spa:por:documento, rus:докуме́нт, tur:doküman, may:dokumen, jpn:ドキュメント
 PWN:dog.n.01		bua	bua	swa:mbwa + fra:ouaf, zho:汪 (wāng), jpn:ワン (wan)
 PWN:doll.n.01		pup	pup	fra:poupée, deu:Puppe, eng:puppet, rus:пупс (pups), vie:búp bê, ktu:popi, heb: בובה (bubá)
 PWN:dollar.n.01		dolar	dolar	
@@ -613,10 +619,12 @@ PWN:emperor.n.01		imperer	imper·er
 PWN:empire.n.02		imperia	imper·ia	eng:fra:empire, spa:imperio, por:império, rus:империя (imperiya), ara:(ʾimbirāṭūriyya), tur:imparatorluk
 PWN:empty.a.01		hali	hali	ara:خَالٍ‎ (xāliy), hin:ख़ाली (xālī), ben:খালি (khali), tel:ఖాళీ (khāḷī), tam:(kali), fas:خالی (xāli), tur:hali
 PWN:end.n.03		fin	fin	eng:finish, fra:spa:fin, por:fim + rus:финал (final), fas: فینال‎ (finâl), jpn:ファイナル (fainaru), swa:fainali, tur:final
+PWN:end_product.n.01		chutet	chut·et	
 PWN:enemy.n.01		inamik	in.am·ik	
 PWN:energy.n.01		energia	energ·ia	eng:energy, spa:energía, por:energia, fra:énergie, rus:энергия (energiya), tur:enerji, fas:انرژی‎ (enerži), jpn:エネルギー (enerugī)
 PWN:engineer.n.01		enjener	enjen·er	eng:engineer, spa:ingeniero, por:engenheiro, rus:инженер (inzhener), hin:mar:इंजीनियर (iñjīniyar), jpn:エンジニア (enjinia), may:insinyur
 PWN:enough.r.01		bas	bas	spa:por:ita:basta + ara:fas:urd:س (bas), hin:(bas), swa:basi
+PWN:enter.v.01		entre	entr'e	eng:enter, por:spa:entrar, fra:entre, deu:eintreten
 PWN:entertainment_industry.n.01 		shou biz	shou biz	
 PWN:environment.n.01		eko	eko	eng:spa:por:eco-, fra:éco-, deu:öko-, rus:эко-, tur:may:eko-, swa:iko-
 PWN:environmental.a.01		ekotik	eko·tik	
@@ -632,6 +640,7 @@ PWN:euro.n.01		euro	euro
 PWN:european.n.01		europan	europa·n	
 PWN:europium.n.01		europium	europ·ium	eng:europium, fra:europium, spa:europio, por:európio, rus:европий, jpn:ユウロピウム, kor:유로퓸, vie:europi, hin:युरोपियम, ben:ইউরোপিয়াম, may:europium, swa:europi, ara: يروبيوم
 PWN:even.r.01		hata	hata	ara: حَتَّى (ḥatta), fas:حَتّی, tur:hau:hatta, swa:hata, ful:haa, spa:hasta, por:até
+PWN:example.n.01		misal	misal	ara:مِثَال, may:misal, tur:misal, fas:مِثال, hin:मिसाल
 PWN:excellent.s.01		top klasik	top klas·ik	
 PWN:exchange.v.01		yek	yek	
 PWN:exclude.v.01		exkluze	ex.kluz'e	
@@ -659,6 +668,7 @@ PWN:factory.n.01		fateria	fa·ter·ia
 PWN:fairy.n.01		pari	pari	fas: پری‎ (pari), hin:परी (parī), ben:পরী (pôri), may:tur:peri, hau:fari, eng:fairy; peri, fra:péri, deu:Peri, rus:пери (peri)
 PWN:family.n.02		famil	famil	deu:Familie, eng:family, spa:familia, por:família, fra:famille, fas: فامیل‎ (fâmil), swa:familia, may:famili
 PWN:fan.n.03		filer	fil·er	
+PWN:fantasy.n.02		fantazik	fantaz·ik	eng:fantasy, spa:fantástico, rus:фэ́нтези, swa:fantasia, jpn:ファンタジー
 PWN:far.a.01		tele	tele	eng:spa:por:may:tele-, fra:télé-, rus:теле- (tele-)
 PWN:farmer.n.01		agrer	agr·er	
 PWN:fast.r.01		rapid	rap·id	
@@ -677,6 +687,7 @@ PWN:feminist.n.01		feministe	fem·in·ist'e
 PWN:fencing.n.03		gem sut	gem·sut	
 PWN:fender.n.01		poto fender	poto fend·er	
 PWN:fermium.n.01		fermium	ferm·ium	eng:fermium, fra:fermium, spa:fermio, por:férmio, rus:фермий, zho:镄 (fèi), jpn:フェルミウム, kor:페르뮴, vie:fecmi, hin:फर्मियम, ben:ফার্মিয়াম, may:fermium, swa:fermi, ara: فرميوم
+PWN:fiction.n.01		fatkisa	fat·kisa	
 PWN:field.n.01		medan	medan	ara: مَيْدَان‎ (maydān), fas:(meydan), hin:मैदान (maidān), ben:ময়দান (moidan), may:medan, tur:meydan, swa:medani, rus:майдан (maydan)
 PWN:field_hockey.n.01		hoki	hoki	
 PWN:fight.v.03		jihad	jihad	
@@ -722,6 +733,7 @@ PWN:function.n.03		rol	rol	eng:role, fra:rôle, deu:Rolle, rus:роль (rol’)
 PWN:gadolinium.n.01		gadolinium	gadolin·ium	eng:gadolinium, fra:gadolinium, spa:gadolinio, por:gadolínio, rus:гадолиний, zho:钆 (gá), jpn:ガドリニウム, kor:가돌리늄, vie:gađolini, hin:ग्याडोलिनियम, ben:গ্যাডোলিনিয়াম, may:gadolinium, swa:gadolini, ara: جدولينيوم
 PWN:galaxy.n.03		galaxia	galax·ia	eng:galaxy, spa:galaxia, por:galáxia, fra:galaxie, rus:галактика (galaktika), tur:may:galaksi, hin:गैलेक्सी (gaileksī)
 PWN:gallium.n.01		galium	gal·ium	eng:gallium, fra:gallium, spa:galio, por:gálio, rus:галлий, zho:镓 (jiā), jpn:ガリウム, kor:갈륨, vie:gali, hin:गैलियम, ben:গ্যালিয়াম, may:galium, swa:gali, ara: جاليوم
+PWN:game.n.03		gem	gem	eng:game, jpn:ゲーム	
 PWN:garden.n.01		garde	gard'e	eng:garden, deu:Garten, fra:jardin, spa:jardín, por:jardim, rus:огород (ogorod), ara: جردة (jarda)
 PWN:garden.n.01		gardin	gard·in	
 PWN:garlic.n.01		lasun	lasun	hin:लहसुन (lahsun), ben:রসুন (rôśun) + zho:大蒜 (dàsuàn), yue:大蒜 (daai6 syun3), kor:대산 (daesan)
@@ -788,6 +800,7 @@ PWN:hand.n.01		hande	hand'e	eng:hand, deu:Hand + hin:हाथ (hāth), ben:হ
 PWN:handle.n.01		handul	hand·ul	
 PWN:hang.v.01		pende	pend'e	eng:pendant, fra:pendre, por:pender + spa:péndulo, tur:pandül, fas:پاندول‎ (pândul), ara: بَنْدُول‎ (bandūl), may:bandul
 PWN:hanukkah.n.01		hanuka	hanuka	
+PWN:happiness.n.02		hapita	hapi·ta	
 PWN:happy.a.01		hapi	hapi	eng:deu:happy, jpn:ハッピー (happī), zho:嗨皮 (hāipí), yue:happy (hep1 pi4)
 PWN:hassium.n.01		hesium	hes·ium	eng:hassium, fra:hassium, spa:hasio, por:hássio, rus:хассий, zho: (hēi), jpn:ハッシウム, kor:하슘, vie:hassi, hin:हसियम, ben:হ্যাসিয়াম, may:hassium, swa:hassi, ara: هاسيوم
 PWN:head.n.01		kap	kap	deu:Kopf, spa:cabeza; cabo, por:cabeça; cabo, may:kepala + hin:कपाल (kapāl) + eng:cape, fra:cap + yue:岬 (gaap3), kor:갑 (gap)
@@ -869,8 +882,11 @@ PWN:indium.n.01		hindium	hind·ium	eng:indium, fra:indium, spa:indium, por:índi
 PWN:indivisible.a.01		intomebil	in.tom·e·bil	
 PWN:inhumane.a.01	fig.	inhomanik	in.hom·an·ik	
 PWN:injury.n.01		trauma	trauma	eng:fra:may:trauma, deu:Trauma, spa:por:traumatismo, rus:травма (travma), tur:travma
+PWN:input.n.04		entret	entr·et	
 PWN:insult.n.02		dusnim	dus.nim	
 PWN:intend.v.01		plan	plan	
+PWN:interact.v.01		konat	kon·at	
+PWN:interactional.s.01		konative	kon·at·iv'e	
 PWN:internet.n.01		internet	internet	
 PWN:intolerable.a.01		intolerabil	in.tolera·bil	
 PWN:invent.v.01		heure	heur’e	
@@ -953,6 +969,7 @@ PWN:less.r.01		les	les	eng:less
 PWN:less.r.01		min	min	eng:minimum, spa:por:menos; mínimo, fra:moins; minimum, rus:менее (meneye); минимум (minimum), eng:minimum + zho:迷你 (mínǐ)
 PWN:lettuce.n.02		letus	letus	eng:lettuce, jpn:レタス (retasu), hau:latas, hin:लेटिष (leṭiṣ), ben:লেটুস (leṭus), fra:laitue
 PWN:library.n.01		kitab kan	kitab kan	
+PWN:license.n.01		halaldokumen	halal·dokumen	
 PWN:licorice.n.01		glukoriza	gluk·o·riza	ara: سُوس (sus), spa:alcazus, por:alcaçuz, swa:susi
 PWN:licorice.n.02		glukoriza kandi	gluk·o·riza kandi	
 PWN:life.n.11		bio	bio	eng:deu:fra:spa:por:pol:may:swa:tur:bio-, rus:био- (bio-)
@@ -960,6 +977,7 @@ PWN:light.n.01		fot	fot	ell:φωτο- (foto-), eng:fra:deu:photo-, spa:por:foto-
 PWN:like.v.02		hao	hao	zho:好 (hǎo), yue:好 (hou2), vie:hảo; hiếu, jpn:好 (kō), kor:호 (ho)
 PWN:limit.n.01		had	had	ara: حَدّ‎ (ḥadd), fas: حد‎ (hadd), hin:हद (had), ben:হদ্দ (hôddô), tel:హద్దు (haddu), swa:hadi, hau:haddi, tur:hat
 PWN:linguist.n.02		polibashiste	poli·bash·ist’e	
+PWN:linguistic.a.01		bashik	bash·ik	
 PWN:linguistics.n.01		basholojia	bash·o·loj·ia	
 PWN:link.n.02		linke	link’e	eng:link, fra:lien, deu:Link, fas:لینک • (link), jpn:リンク (rinku) + zho:連結 (liánjié), yue:連結 (lin4 git3), hak:連結 (lièn-kiet), vie:liên kết
 PWN:link.n.09		linke	link’e	
@@ -974,6 +992,7 @@ PWN:little.r.01		kam	kam	deu:kaum + fas: کم‎ (kam), hin:कम (kam), ben:�
 PWN:little_sister.n.01		jun sis	jun sis	
 PWN:liver.n.01		gan	gan	zho:肝 (gān), yue:肝 (gon1), wuu:肝 (koe1), kor:간 (gan), jpn:肝臓 (kanzō), vie:gan + swa:ini
 PWN:lizard.n.01		saur	saur	ell:σαύρα (saura), eng:-saur, fra:-saure, spa:-saurio, por:-sauro, rus:-завр (-zavr), hin:ben: may:-saur(us) + hin:सरट (saraṭ)
+PWN:location.n.01		plas	plas	eng:fra:place, deu:Platz
 PWN:long.a.01		long duran	long dura·n	
 PWN:long.a.02		long	long	eng:fra:long, deu:lang, por:longo
 PWN:love.v.03		love	lov'e	
@@ -1010,6 +1029,8 @@ PWN:map.n.01		harte	hart'e	eng:chart, fra:carte, spa:por:carta, rus:карта (
 PWN:mapmaking.n.01		hartografia	kart·o·graf·ia	
 PWN:march.n.01		mes tri	mes tri	
 PWN:marijuana.n.01		ganja	ganja	hin:गांजा (gāñjā), urd:(gānjā), pnb:ਗਾਂਜਾ (gāñjā), ben:গাঁজা (gañja), tel:గంజాయి (gañjāyi), tam:கஞ்சா (kañcā), khm:កញ្ឆា (kɑñchaa), tha:กัญชา (gan-chaa), vie:cần sa, eng:por:may:ganja, jpn:ガンジャ (gānjya)
+PWN:mark.n.04		marke	mark'e	eng:mark, por:marco, spa:marca, deu:Marke, ben:মার্কা, jpn:マーク
+PWN:mark.n.10		marke	mark'e	
 PWN:marketplace.n.02		bazar	bazar	fas:urd: بازار (bāzār), hin:बाज़ार (bāzār), tam:பசார் (pasār), fra:spa:por:bazar, eng:bazaar, rus:базар (bazar), may: pasar, zho:巴扎 (bāzhā); 巴剎 (bāshā)
 PWN:marriage.n.01		gamia	gam·ia	eng:-gamy, fra:-gamie, spa:por:-gamia, rus:-гамия (-gamiya)
 PWN:martial_art.n.01		vudao	vu·dao	
@@ -1051,6 +1072,10 @@ PWN:military.a.01		jangik	jang·ik
 PWN:milk.n.01		milke	milk'e	eng:milk, deu:Milch, jpn:ミルク  (miruku), kor:밀크 (milkeu), lin:míliki, rus:молоко (moloko)
 PWN:mill.n.04		mol kan	mol kan	
 PWN:million.s.01		mega	mega	eng:fra:spa:por:may:tur:mega-, rus:мега- (mega-), jpn:メガ (mega), kor:메가- (mega-)
+PWN:mine.n.01		madineria	madin·er·ia	
+PWN:mine.v.01		teik madin	teik madin	
+PWN:miner.n.01		madiner	madin·er	
+PWN:mineral.n.01		madin	madin	ara:مَعْدِن, fas:معدن, tur:maden, swa:madini, ell:μαντέμι, eng:mine, por:spa:mina
 PWN:minimize.v.01		minimifa	min·im·ifa	
 PWN:minister.n.02		vazir	vazir	ara: وَزِير‎ (wazīr), fas: وَزیر‎ (vazir), hin:वज़ीर (vazīr), ben:উজির (ujir), tur:vezir, swa:may:wazir + eng:vizier, deu:Wesir, fra:por:vizir, spa:visir, rus:визирь (vizir')
 PWN:minor.s.10		minik	min·ik	
@@ -1080,6 +1105,7 @@ PWN:mouse.n.01		mushu	mush	rus:мышь (myś), pol:mysz, fas: موش‎ (muš) 
 PWN:move.v.04		migra	migra	fra:eng:migration, spa:migración, por:migração, rus:миграция (migratsiya)
 PWN:mule.n.01		ihamar	iha·mar	
 PWN:multilingual.a.01		polibashik	poli·bash·ik	
+PWN:mundane.s.02		dunial	dun·ial	
 PWN:muscle.n.01		muskul	musk·ul	eng:fra:muscle, spa:por:músculo, deu:Muskel, rus:мускул (muskul), swa:msuli
 PWN:music.n.01		muzik	muz·ik	eng:music, deu:Musiek, fra:musique, spa:por:música, rus:музика (muzika), fas: موسیقی (musiği), hin:मूसीक़ी (mūsīqī), ara: موسيقى (mūsīqā), swa:muziki, tur:müzik, may:musik
 PWN:musician.n.01		muziker	muz·ik·er	
@@ -1167,6 +1193,7 @@ PWN:paintbrush.n.01		pente brosh	pent·e brosh
 PWN:palladium.n.01		paladium	palad·ium	eng:palladium, fra:palladium, spa:paladio, por:paládio, rus:палладий, zho:钯 (bǎ), jpn:パラジウム, kor:팔라듐, vie:palađi, hin:पलाडियम, ben:প্যালাডিয়াম, may:paladium, swa:paladi, ara: بلاديوم
 PWN:paper.n.01		kaguz	kaguz	zho:榖纸 (gǔzhǐ), yue:榖紙 (guk1zi2), jpn:榖紙 (kokushi), + fas:(kâğaz), hin:काग़ज़ (kāġaz), ben:কাগজ (kagôj), tur:kâğıt, ara:(kāḡid), kan:ಕಾಗದ (kāgada), tel:కాగితము (kāgitamu), tam:காகிதம் (kākitam), wol:keyit, uig:(qeghez)
 PWN:paper.n.01		karte	kart'e	ara: قِرْطَاس m (qirṭās), swa:karatasi, hau:takarda, may:kertas, khm:ក្រដាស (krɑdaah), tha:กระดาษ (kra-dat) + fra:carton, spa:cartón
+PWN:parameter.n.01		parametre	para·metr'e	eng:parameter, por:parâmetro, spa:parámetro, rus:пара́метр, jpn:パラメータ
 PWN:parent.n.01		chin	chin	zho:親 (qīn), yue:親 (can), wuu:親 (qin), jpn:親 (shin), kor:친 (chin)
 PWN:park.n.01		parke	park'e	eng:deu:tur:pol:park, spa:por:parque, fra:parc, rus:парк (park), hin:पार्क (pārk)
 PWN:parrot.n.01		papagai	papagai	ara: بَبَغَاء‎ (babaḡāʾ), tur:papağan, deu:Papagei, spa:papagayo, por:papagaio, rus:попугай (popugay), jin:八哥 (bāgē)
@@ -1187,6 +1214,7 @@ PWN:people.n.01		nas	nas	ara:(nās) + eng:fra:nation, deu:Nazion, por:nação, s
 PWN:pepper.n.01		pipal	pipal	eng:pepper, deu:Pfeffer, fra:povre, spa:pebre, ita:pepe, ben:পিপুল (pipul), fas: پلپل⁩ (pelpel), tel:పిప్పలి (pippali), tur:biber, ara: فِلْفِل⁩ (filfil), swa:pilipili, zho:荜拔 (bìbá)
 PWN:pepper.n.04		piman	piman	fra:piment, spa:pimiento, por:pimento, jpn:ピーマン (pīman), kor:피망 (pimang)
 PWN:perfect.a.01		perfat	per.fa·t	
+PWN:permission.n.01		halal	halal	
 PWN:persistent.a.03		persisten	per.sist'en	
 PWN:person.n.01		hom	hom	
 PWN:pestle.n.03		piste	pist'e	eng:fra:may:tur:piston, spa:pistón, por:pistão, rus:пест (pest), jpn:ピストン (pisuton), kor:피스톤 (piseuton)
@@ -1513,6 +1541,7 @@ PWN:t'ai_chi.n.01		tai gik kuen	tai·gik·kuen
 PWN:table.n.02		meza	meza	por:spa:mesa, hin:मेज़ (mez), swa:meza, may:meja, tam:மேசை (mesei), fas: میز‏‎ (miz), tur:masa
 PWN:table_knife.n.01		can dau	can dau	
 PWN:tae_kwon_do.n.01		taikuendao	tai·kuen·dao	
+PWN:take.v.04		teik	teik	eng:take
 PWN:talk.v.01		tok	tok	eng:talk, pcm:tok
 PWN:tall.a.01		gau	gau	zho:高 (gāo), yue:高 (gou1), wuu:高 (kau1), jpn:高 (kō), kor:고 (go), vie:cao
 PWN:tampon.n.01		tapon	tap·on	
@@ -1528,6 +1557,7 @@ PWN:teapot.n.01		cha pote	cha pot'e
 PWN:tear.n.01		ain sui	ain sui	tam:கண்ணீர் (kaṇṇīr), mal:കണ്ണുനീർ (kaṇṇunīr), tel:(kannīru), kor:눈물 (nunmul), vie:nước mắt, may:air mata, tha:น้ำตา
 PWN:technetium.n.01		tehnetium	tehn·et·ium	eng:technetium, fra:technétium, spa:tecnetio, por:tecnécio, rus:технеций, zho:锝 (dé), jpn:テクネチウム, kor:테크네튬, vie:tecnexi, hin:टेक्निशियम, ben:টেকনিসিয়াম, may:teknetium, swa:tekineti, ara: تكنيتيوم
 PWN:technology.n.01		teknolojia	tekn·o·loj·ia	
+PWN:tectonics.n.02		plate tektonik	plat'e tektonik	eng:tectonics, spa:tectónica, rus:текто́ника, tur:tektoniği, ara:التكتونية, hin:विवर्तनिकी, may:tektonik, jpn:テクトニクス
 PWN:telephone.n.01		telefon	tele·fon	
 PWN:telescope.n.01		teleskope	tele·skop'e	
 PWN:television.n.01		televizion	tele·viz·ion	

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -733,7 +733,7 @@ PWN:function.n.03		rol	rol	eng:role, fra:rôle, deu:Rolle, rus:роль (rol’)
 PWN:gadolinium.n.01		gadolinium	gadolin·ium	eng:gadolinium, fra:gadolinium, spa:gadolinio, por:gadolínio, rus:гадолиний, zho:钆 (gá), jpn:ガドリニウム, kor:가돌리늄, vie:gađolini, hin:ग्याडोलिनियम, ben:গ্যাডোলিনিয়াম, may:gadolinium, swa:gadolini, ara: جدولينيوم
 PWN:galaxy.n.03		galaxia	galax·ia	eng:galaxy, spa:galaxia, por:galáxia, fra:galaxie, rus:галактика (galaktika), tur:may:galaksi, hin:गैलेक्सी (gaileksī)
 PWN:gallium.n.01		galium	gal·ium	eng:gallium, fra:gallium, spa:galio, por:gálio, rus:галлий, zho:镓 (jiā), jpn:ガリウム, kor:갈륨, vie:gali, hin:गैलियम, ben:গ্যালিয়াম, may:galium, swa:gali, ara: جاليوم
-PWN:game.n.03		gem	gem	eng:game, jpn:ゲーム	
+PWN:game.n.03		geim	geim	eng:game, jpn:ゲーム	
 PWN:garden.n.01		garde	gard'e	eng:garden, deu:Garten, fra:jardin, spa:jardín, por:jardim, rus:огород (ogorod), ara: جردة (jarda)
 PWN:garden.n.01		gardin	gard·in	
 PWN:garlic.n.01		lasun	lasun	hin:लहसुन (lahsun), ben:রসুন (rôśun) + zho:大蒜 (dàsuàn), yue:大蒜 (daai6 syun3), kor:대산 (daesan)


### PR DESCRIPTION
This PR adds the words _universal_, _dunial_, and _plas_, which are in the documentation of pandunia.info but were not in the dictionary.  It also adds the new words _bashkonstruer_ ('conlanger'), _geo plate_ ('tectonic plate'), _mach_ ('contest'), _dokumen_ ('document'), _entre_ ('enter'), _entret & chutet_ ('input & output'), _misal_ ('example'), _fantazik_ ('fantasy genre'), _fatkisa ('fiction')_, _geim_ ('game'), _hapita_ ('happiness'), _konat_ ('interact'), _konative_ ('interactive'), _halaldokumen_ ('license'), _bashik_ ('linguistic'), _marke_ ('mark'), _teik_ ('take'), _madin_ ('mineral'), _teik madin_ ('mine'), _madiner_ ('miner'), _madineria_ ('mine'), _parametre_ ('parameter'), and _plate tektonik_ ('plate tectonics').  Finally, it adds two new meanings to _halal_ ('may' and 'permission').

I installed WSL so I can run the Bash scripts myself now.  I think it will make everything much easier.