### PR TITLE
new Pandunia words: politik, false, proses, and more

### DIFF
--- a/concepts/E/eng-definition.tsv
+++ b/concepts/E/eng-definition.tsv
@@ -176,6 +176,8 @@ PLX:parent’s elder brother.n
 PLX:parent’s elder sister.n	
 PLX:parent’s younger brother.n	
 PLX:parent’s younger sister.n	
+PLX:prepend.v	add to the very beginning
+PLX:pseudorandom.a	having the properties of a random sequence, but actually being generated using a deterministic algorithm
 PLX:quantity of.pp	having the specified quantity of the specified thing
 PLX:ramen.n	a noodle dish typically served in a hot broth with toppings
 PLX:shamanistic song.n	
@@ -2744,6 +2746,7 @@ PWN:explosion.n.02	the act of exploding or bursting
 PWN:explosive.n.01	a chemical substance that undergoes a rapid chemical change (with the production of gas) on being heated or struck
 PWN:explosive_device.n.01	device that bursts with sudden violence from internal energy
 PWN:export.n.01	commodities (goods or services) sold to a foreign country
+PWN:expose.v.01	expose or make accessible to some action or influence
 PWN:expose.v.03	to show, make visible or apparent
 PWN:express.v.01	give expression to
 PWN:express.v.02	articulate; either verbally or with a cry, shout, or noise
@@ -2799,6 +2802,7 @@ PWN:fairy.n.01	A supernatural flying humanoid possessing magical powers.
 PWN:fairytale.n.01	A fairy tale is a type of short story that typically features folkloric fantasy characters, such as dwarves, dragons, elves, fairies, giants, gnomes, goblins, griffins, mermaids, talking animals, trolls, unicorns, or witches, and usually magic or enchantments.
 PWN:faith.n.02	complete confidence in a person or plan etc
 PWN:faithful.a.01	Steadfast in affection.
+PWN:fake.s.02	not genuine or real; being an imitation of the genuine article
 PWN:fall.n.01	The season after summer and before winter, traditionally from September 21 to December 20 in the northern hemisphere and from March 21 to June 20 in the southern hemisphere.
 PWN:fall.n.03	the lapse of mankind into sinfulness because of the sin of Adam and Eve
 PWN:fall.n.05	a lapse into sin; a loss of innocence or of chastity
@@ -5338,6 +5342,7 @@ PWN:policy.n.02	a line of argument rationalizing the course of action of a gover
 PWN:polish.v.01	make (a surface) shine
 PWN:polish.v.02	improve or perfect by pruning or polishing
 PWN:polish.v.03	bring to a highly developed, finished, or refined state
+PWN:political.a.03	of or relating to the profession of governing
 PWN:political_campaign.n.01	a race between candidates for elective office
 PWN:political_orientation.n.01	an orientation that characterizes the thinking of a group or nation
 PWN:political_system.n.01	the members of a social organization who are in power
@@ -5568,6 +5573,7 @@ PWN:psychosis.n.01	any severe mental disorder in which contact with reality is l
 PWN:puberty.n.01	the time of life when sex glands become functional
 PWN:pubic_hair.n.01	Dense, coarse hair that grows on the male and female genital area beginning in puberty.
 PWN:public.a.01	not private; open to or concerning the people as a whole
+PWN:public_domain.n.01	property rights that are held by the public at large
 PWN:public_opinion.n.01	a belief or sentiment shared by most people; the voice of the people
 PWN:public_square.n.01	an open area at the meeting of two or more streets
 PWN:public_transport.n.01	conveyance for passengers or mail or freight
@@ -6711,6 +6717,7 @@ PWN:subject.n.02	something (a person or object or scene) selected by an artist o
 PWN:subjugation.n.01	forced submission to control by others
 PWN:submerge.v.02	cover completely or make imperceptible
 PWN:submission.n.01	something (manuscripts or architectural plans and models or estimates or works of art of all genres etc.) submitted for the judgment of others (as in a competition)
+PWN:submit.v.02	put before
 PWN:subsequently.r.01	Later or after something else has happened or happens.
 PWN:subsequently.r.01	happening at a time subsequent to a reference time
 PWN:substance.n.01	the real physical matter of which a person or thing consists

--- a/data/id_map.tsv
+++ b/data/id_map.tsv
@@ -2742,6 +2742,7 @@ PWN:explosion.n.02	00377364-n
 PWN:explosive.n.01	03304730-n				
 PWN:explosive_device.n.01	03305522-n				
 PWN:export.n.01	03306207-n				
+PWN:expose.v.01	02112029-v				
 PWN:expose.v.03	02140033-v				
 PWN:express.v.01	00943837-v				
 PWN:express.v.02	00940384-v				
@@ -2797,6 +2798,7 @@ PWN:fairy.n.01	09540430-n				1812
 PWN:fairytale.n.01	07222581-n	2937	18-99901	Märchen::N	
 PWN:faith.n.02	05943066-n				
 PWN:faithful.a.01	00958880-a	100	16-65		
+PWN:fake.s.02	01573238-a				
 PWN:fall.n.01	15236859-n	1276	14-77	Herbst::N	3272
 PWN:fall.n.03	07478531-n				
 PWN:fall.n.05	00756919-n				
@@ -5340,6 +5342,7 @@ PWN:policy.n.02	06656408-n
 PWN:polish.v.01	01245637-v				
 PWN:polish.v.02	00474017-v				
 PWN:polish.v.03	00473799-v				
+PWN:political.a.03	02857587-a				
 PWN:political_campaign.n.01	07472929-n				1641
 PWN:political_orientation.n.01	06212839-n				
 PWN:political_system.n.01	08367880-n				
@@ -5570,6 +5573,7 @@ PWN:psychosis.n.01	14398067-n
 PWN:puberty.n.01	15148295-n				
 PWN:pubic_hair.n.01	05263587-n	36	4-145		
 PWN:public.a.01	01861205-a				1770
+PWN:public_domain.n.01	13243668-n				
 PWN:public_opinion.n.01	05949726-n				
 PWN:public_square.n.01	08619620-n				
 PWN:public_transport.n.01	04019101-n				
@@ -6713,6 +6717,7 @@ PWN:subject.n.02	04347225-n
 PWN:subjugation.n.01	13996300-n				
 PWN:submerge.v.02	01339294-v				
 PWN:submission.n.01	07167578-n				
+PWN:submit.v.02	00878136-v				
 PWN:subsequently.r.01	00061203-r				
 PWN:subsequently.r.01	00061203-r	2093		danach::ADV	
 PWN:substance.n.01	00019613-n				3300

--- a/dict/E/eng.tsv
+++ b/dict/E/eng.tsv
@@ -119,6 +119,8 @@ PLX:or.cnj		or
 PLX:other.pro		alter		
 PLX:other.pro		other		
 PLX:outside.pp		outside		
+PLX:prepend.v		prepend		
+PLX:pseudorandom.a		pseudorandom		
 PLX:ramen.n		ramen		
 PLX:ramen.n		soup noodles		
 PLX:should.v		ought		
@@ -6767,6 +6769,7 @@ PWN:explosive.n.01		explosive
 PWN:explosive_device.n.01		explosive device		
 PWN:export.n.01		export		
 PWN:export.n.01		exportation		
+PWN:expose.v.01		expose		
 PWN:expose.v.03		display		
 PWN:expose.v.03		exhibit		
 PWN:expose.v.03		expose		
@@ -6901,6 +6904,13 @@ PWN:fairytale.n.01		fairytale
 PWN:faith.n.02		faith		
 PWN:faith.n.02		trust		
 PWN:faithful.a.01		faithful		:fidēs
+PWN:fake.s.02		counterfeit		
+PWN:fake.s.02		fake		
+PWN:fake.s.02		false		
+PWN:fake.s.02		faux		
+PWN:fake.s.02		imitation		
+PWN:fake.s.02		phony		
+PWN:fake.s.02		spurious		
 PWN:fall.n.01		autumn		:autumnus
 PWN:fall.n.01		fall		
 PWN:fall.n.03		Fall		
@@ -12716,6 +12726,7 @@ PWN:polish.v.03		polish
 PWN:polish.v.03		polish up		
 PWN:polish.v.03		round		
 PWN:polish.v.03		round off		
+PWN:political.a.03		political		
 PWN:political_campaign.n.01		campaign		
 PWN:political_campaign.n.01		political campaign		
 PWN:political_campaign.n.01		run		
@@ -13274,6 +13285,7 @@ PWN:pubic_hair.n.01		bush
 PWN:pubic_hair.n.01		crotch hair		
 PWN:pubic_hair.n.01		pubic hair		:pūbēs
 PWN:public.a.01		public		
+PWN:public_domain.n.01		public domain		
 PWN:public_opinion.n.01		opinion		
 PWN:public_opinion.n.01		popular opinion		
 PWN:public_opinion.n.01		public opinion		
@@ -16003,6 +16015,9 @@ PWN:submerge.v.02		overwhelm
 PWN:submerge.v.02		submerge		
 PWN:submission.n.01		entry		
 PWN:submission.n.01		submission		
+PWN:submit.v.02		posit		
+PWN:submit.v.02		put forward		
+PWN:submit.v.02		submit		
 PWN:subsequently.r.01		after		
 PWN:subsequently.r.01		afterward		
 PWN:subsequently.r.01		afterwards		

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -62,6 +62,8 @@ PLX:older sibling.n		sen sib	sen sib
 PLX:one.pro		von	von	eng:one, fra:on
 PLX:or.cnj		o	o	eng:or, spa:tgl:o, fra:por:ou, zho:或 (huò), ara:(ʾaw)
 PLX:other.pro		altre	al·tr'e	
+PLX:prepend.v		prepozi	pre.pozi	
+PLX:pseudorandom.a		falsozarik	fals·o·zar·ik	
 PLX:ramen.n		supa men	supa men	
 PLX:should.v		shud	shud	eng:should
 PLX:someone.pro		som von	som von	
@@ -163,6 +165,7 @@ PWN:anus.n.01		anus	anus	eng:fra:anus, por:ânus, spa:ano, deu:Anus, rus:ану�
 PWN:any.s.01		eni	eni	eng:any
 PWN:appear.v.02		fen	fen	
 PWN:appearance.n.01		fen	fen	
+PWN:append.v.01		pospozi	pos.pozi	
 PWN:apple.n.01		aple	apl'e	eng:apple, deu:Apfel, rus:яблоко (yabloko), may:apel, ben:আেপল (apôl), hau:aful
 PWN:apprentice.n.01		seng	seng	zho:生 (shēng), yue:生 (saang1), jpn:生 (sei), kor:生 (saeng), vie:sinh + eng:deu:fra:spa:por:may:sensei, rus:сэнсэй (sensey)
 PWN:approve.v.01		aprova	a.prova	
@@ -661,6 +664,8 @@ PWN:expel.v.01		expele	ex.pel'e
 PWN:explain.v.01		exple	ex.pl’e	
 PWN:explicit.a.01		explik	ex.pl·ik	
 PWN:explosion.n.01		bum	bum	eng:boom, deu:Bumm, fra:boum, spa:por:bum, hin:बूम (būm), zho:砰 (pēng), kor:펑 (peong), vie:bùm
+PWN:expose.v.01		expozi	ex.pozi	
+PWN:expose.v.03		expozi	ex.pozi	
 PWN:extent.n.01		extendia	ex.tend·ia	
 PWN:extreme.s.01		tai	tai	zho:太 (tài), yue:太 (taai3), vie:thái, jpn:太 (tai), kor:태 (tae)
 PWN:eye.n.01		ain	ain	eng:eye + ara: عين (ʕayn), may:ain + zho:眼 (yǎn)
@@ -669,6 +674,8 @@ PWN:fabrication.n.01		mit	mit	ell:μῦθος (mythos), eng:myth, deu:Mythos, fr
 PWN:face.n.01		muka	muka	ben:মুখ (mukh), hin:मुख (mukh), tam:முகம் (mukam), tel:(mukhamu), may:muka, tgl:mukha
 PWN:factory.n.01		fateria	fa·ter·ia	
 PWN:fairy.n.01		pari	pari	fas: پری‎ (pari), hin:परी (parī), ben:পরী (pôri), may:tur:peri, hau:fari, eng:fairy; peri, fra:péri, deu:Peri, rus:пери (peri)
+PWN:fake.s.02		false	fals'e	eng:false, por:spa:falso, fra:faux, deu:falsch, rus:фальшь
+PWN:false.a.01		false	fals'e	
 PWN:family.n.02		famil	famil	deu:Familie, eng:family, spa:familia, por:família, fra:famille, fas: فامیل‎ (fâmil), swa:familia, may:famili
 PWN:fan.n.03		filer	fil·er	
 PWN:fantasy.n.02		fantazia	fantaz·ia	eng:fantasy, spa:fantástico, rus:фэ́нтези, swa:fantasia, jpn:ファンタジー
@@ -710,6 +717,7 @@ PWN:fluid.s.02		darik	dar·ik
 PWN:fluorine.n.01		flur	flur	eng:fluorine, fra:fluor, spa:flúor, por:flúor, rus:фтор, zho:氟 (fú), jpn:フッ素, kor:플루오르, vie:flo, hin:फ्लोरीन, ben:ফ্লুরিন, may:fluor, swa:florini, ara: فلور
 PWN:foam.n.01		pena	pena	rus:пена (pena), hin:फेन (phena), ben:ফেনা (phena), tam:பேனம் (pēṉam)
 PWN:folk.n.01		pop	pop	eng:people, fra:peuple, spa:pueblo, por:povo + deu:populär, rus:популярный (populyarnïy), may:populer, tur:popüler, zho:波普 (bōpǔ) + jpn:ポピュリズム (popyurizumu), kor:포퓰리즘 (popyullijeum)
+PWN:following.s.02		posik	pos·ik	
 PWN:foot.n.01		fut	fut	eng:foot, deu:Pfote
 PWN:football.n.01		futbol	fut·bol	eng:fra:football, spa:fútbol, por:futebol, deu:Fußball, hin:फ़ुटबॉल (fuṭbŏl), urd:(fuṭ bāl), ben:ফুটবল (phuṭbôl), rus:футбол (futbol), tha:ฟุตบอล (th) (fút-bɔn), jpn:フットボール (futtobōru), zul:ibhola
 PWN:foreigner.n.01		alian	al·ia·n	
@@ -772,6 +780,7 @@ PWN:goose.n.01		gansa	gansa	spa:por:ganso, hin:हंस (hans), ben:হাঁ�
 PWN:gospel.n.01		evanjil	ev·anjil	
 PWN:govern.v.03		krate	krat'e	
 PWN:government.n.01		kratia	krat·ia	eng:-cracy, fra:-cratie, spa:por:-cracia, rus:-кратия (kratiya), ara:(-qratiya), may:swa:-krasi
+PWN:government.n.01		polite	polit'e	eng:policy, por:spa:política, deu:Politik, rus:поли́тика, tur:politika, may:polisi
 PWN:grain.n.01		gran	gran	eng:fra:grain, spa:grano, por:grão + rus:гранит (granit), tur:vie:may:granit, ara:جرانيت (jaraniat), hin:ग्रेनाइट (grenait)
 PWN:gram.n.01		gram	gram	eng:gram, deu:Gramm, fra:gramme, spa:gramo, por:grama, rus:грамм (gramm), fas: گرم‎ (geram), hin:ग्राम (grām), ben:গ্রাম (gram), ara: غْرَام‎ (ḡrām), ful:giram, swa:gramu, jpn:グラム (guramu), kor:그램 (geuraem), vie:gam, may:tur:gram
 PWN:gram_molecule.n.01		mol	mol	
@@ -1268,7 +1277,9 @@ PWN:pocketknife.n.01		jeb dau	jeb dau
 PWN:poison.n.01		toxe	tox'e	eng:toxic, fra:toxique, spa:por:tóxico, rus:токсичний (toksicniy), may:toksik + zho:毒 (dú), yue:毒 (duk6), wuu:毒 (do’), jpn:毒 (doku/toku), kor:독 (dok), vie:độc
 PWN:poisonous.s.01		toxik	tox·ik	
 PWN:pole.n.01		gik	gik	zho:极 (jí), yue:極 (gik6), jpn:極 (kyoku), kor:극 (geuk), vie:cực
+PWN:political.a.03		politikal	polit·ik·al	
 PWN:politician.n.01		politiste	polit·ist'e	
+PWN:politics.n.05		politik	polit·ik	
 PWN:polonium.n.01		polskium	polsk·ium	eng:polonium, fra:polonium, spa:polonio, por:polónio, rus:полоний, zho:钋 (pō), jpn:ポロニウム, kor:폴로늄, vie:poloni, hin:पोलोनियम, ben:পোলনিয়াম, may:polonium, swa:poloni, ara: بولونيوم
 PWN:polygamy.n.01		poligamia	poli.gam·ia	
 PWN:polygon.n.01		poligon	poli·gon	
@@ -1283,6 +1294,7 @@ PWN:porcelain.n.01		chini	chini	zho:瓷 (cí) + eng:chinaware, hin:चीनी 
 PWN:port.n.01		porte	port'e	eng:port, fra:porte, spa:puerto, por:porto, rus:порт (port), hin:पोर्ट (porṭ), urd:(porṭ), ben:পোর্ট (porṭ), tha:พอร์ต (phot)
 PWN:position.n.04		asan	asan	hin:आसन (āsan), tel:ఆసనము (āsanamu), eng:spa:por:asana, deu:Asana, rus:асана (asana)
 PWN:positive.s.10		yang	yang	
+PWN:postpone.v.01		pospozi	pos.pozi	
 PWN:pot.n.01		pot	pot	eng:fra:pot, spa:por:pote, may:poci, jpn:ポット (potto), kor:포트 (poteu), ful:pooti; fotiire
 PWN:potassium.n.01		kalium	kal·ium	rus:калий, jpn:カリウム, vie:kali, may:kalium, swa:kali
 PWN:potato.n.01		papata	papata	spa:papa; patata, fra:patate, por:batata, eng:potato, tur:patates, ara: بَطَاطِس (baṭāṭis), swa:mbatata
@@ -1296,8 +1308,10 @@ PWN:prayer.n.01		dua	dua	ara: دُعَاء‏  (duʿāʾ), fas: دعا (do'â), 
 PWN:present.a.01		zaitik	zai·tik	
 PWN:press.v.01		pres	pres	
 PWN:prevail.v.03		persiste	per.sist'e	
+PWN:previous.s.01		pretik	pre·tik	
 PWN:print.v.04		impres	im.pres	
 PWN:printer.n.02		impreser	im.pres·er	
+PWN:procedure.n.01		proses	proses	eng:process, por:processo, spa:proceso, rus:проце́сс (procéss), tur:may:proses, jpn:プロセス (purosesu)
 PWN:produce.v.02		bina	bina	ara: بِنَاء‎ (bināʾ), hin: बनाना (banānā), fas:(banā), tur:may:bina + spa:albañil, por:alvenel + jpn:ビル (biru)
 PWN:program.n.07		programa	pro.grama	
 PWN:promethium.n.01		prometium	promet·ium	eng:promethium, fra:prométhium, spa:prometio, por:promécio, rus:прометий, zho:钷 (pǒ), jpn:プロメチウム, kor:프로메튬, vie:prometi, hin:प्रोमेथियम, ben:প্রমিথিয়াম, may:prometium, swa:promethi, ara: بروميثيوم
@@ -1306,14 +1320,17 @@ PWN:promise.v.01		vod	vod
 PWN:pronounce.v.01		fone	fon'e	
 PWN:proof.n.01		prova	prova	
 PWN:prophecy.n.02		deomantia	de·o·mant·ia	
+PWN:propose.v.01		propozi	pro.pozi	
 PWN:protactinium.n.01		protatinium	protatin·ium	eng:protactinium, fra:protactinium, spa:proactinio, por:protacnídio, rus:протактиний, zho:镤 (pú), jpn:プロトアクチニウム, kor:프로트악티늄, vie:protactini, hin:प्रोटैक्टीनियम, ben:প্রোটেক্টিনিয়াম, may:protaktinium, swa:protaktini, ara: بروتكتنيوم
 PWN:prototype.n.01		prototip	proto.tip	
 PWN:public.a.01		demik	dem·ik	
+PWN:public_domain.n.01		demik malia	dem·ik mal·ia	
 PWN:pulp.n.01		fufu	fufu	eng:spa:por:may:swa:fufu, fra:foufou, rus:фуфу (fufu), zho:富富 (fùfù), lin:kon:fufú
 PWN:pump.n.01		pompe	pomp'e	eng:pump, spa:por:bomba, fra:ful:pompe, deu:Pumpe, rus:помпа (pompa), fas: پمپ‎ (pomp), hin:पंप (pamp), ben:পাম্প (pamp), tel:పంపు (pampu), tur:may:pompa, hau:famfo, zho:泵 (bèng), yue:泵 (bam1), jpn:ポンプ (ponpu), kor:펌프 (peompeu), vie:bơm
 PWN:punjabi.n.02		panjab bash	panjab bash	
 PWN:purple.s.01		nil	nil	ara: نِيلِيّ (nīliyy), fas: نیلی (nīlī), ben:নীল (nil), hin:नील (nīl), spa:añil, por:anil, may:tgl:nila
 PWN:purple.s.01		purpur	purpur	eng:purple, deu:Purpur, fra:pourpre, spa:por:púrpura, rus:пурпурный (purpúrnyj), kor:보라 (bora), jpn:紫 (murasaki)
+PWN:put.v.01		pozi	pozi	eng:pose, por:posição, spa:posición, deu:Position, rus:пози́ция (pozícija)
 PWN:pyramid.n.01		piram	piram	eng:pyramid, fra:pyramide, spa:por:pirámide, rus:пирамида (piramida), hin:पिरमिड (pirmiḍ),अहराम (ahrām), ben:পিরামিড (piramiḍ), may:piramida, jpn:ピラミッド (piramiddo), kor:피라미드 (piramideu) + ara:(haram), swa:haram
 PWN:quartz_glass.n.01		kuarze	kuarz'e	deu:Quarz, eng:fra:quartz, spa:cuarzo, rus:кварц (kvarc), tur:kuvars, hin:क्वार्ट्ज (kvārtj), jpn:クオーツ (kuōtsu), may:kuarza
 PWN:question.n.03 		sual	sual	ara: سؤال (su'āl), fas: سؤال‎ (so'âl), hin:सवाल (savāl), ben:সওয়াল (śôwal), may:soal, swa:swali, tur:sual + khm:សួរ (suə)
@@ -1522,6 +1539,7 @@ PWN:study.v.05		stude	stud'e	eng:study, fra:étudier, spa:estudiar, por:estudar,
 PWN:stupid.a.01		idiotik	idiot·ik	
 PWN:styrofoam.n.01		polistiren pena	poli·stir·en pena	
 PWN:subject.n.01		tema	tema	fra: thème, spa: tema, rus: тема (tema), deu:Thema + zho:题目 (tímù)
+PWN:submit.v.02		propozi	pro.pozi	
 PWN:substitute.n.01		vis	vis	eng:fra:spa:por:vice-, rus:вице- (vitse-), deu:vize-
 PWN:substitute.v.01		vis	vis	
 PWN:suffer.v.02		pate	pat'e	deu:eng:fra:patho-, spa:por:pol:tur:may:pato-, rus:пато- (pato-)


### PR DESCRIPTION
adding new Pandunia words: _polite_ (synonym for _kratia_), _politik_ ('politics'), _politikal_ ('political'), _pretik_ ('previus'), _posik_ ('next'), _proses_ ('process'), _false_ ('false'), _falsozarik_ ('pseudorandom'), and _demik malia_ ('public domain').

also adding _pozi_, which was previusly on the Pandunia website but not in the dictionary, and several prefixed versions of it: _pospozi_ ('append' or 'postpone'), _prepozi_ ('prepend'), _propozi_ ('put forward' or 'propose'), and _expozi_ ('expose' literally or figuratively).