### PR TITLE
New Pandunia words: anou, rota, kargo, and more

### DIFF
--- a/concepts/E/eng-definition.tsv
+++ b/concepts/E/eng-definition.tsv
@@ -517,6 +517,7 @@ PWN:anteater.n.02	A mammal of the suborder Vermilingua having elongated snouts a
 PWN:anteroom.n.01	a large entrance or reception room or area
 PWN:antibiotic.a.01	of or relating to antibiotic drugs
 PWN:antic.n.01	a ludicrous or grotesque act done for fun and amusement
+PWN:anticipate.v.03	realize beforehand
 PWN:anticipation.n.01	an expectation
 PWN:antimony.n.01	Antimony, the chemical element with atomic number 51 and symbol Sb.
 PWN:antithesis.n.01	a proposition that is the exact opposite of some other proposition
@@ -2325,6 +2326,7 @@ PWN:disorder.n.01	a physical condition in which there is a disturbance of normal
 PWN:disorder.n.03	a disturbance of the peace or of public order
 PWN:disorder.v.02	bring disorder to
 PWN:disown.v.02	cast off
+PWN:disparate.s.01	fundamentally different or distinct in quality or kind
 PWN:dispatch.n.02	the act of sending off something
 PWN:dispatch.v.01	send away towards a designated goal
 PWN:disperse.v.02	To throw or drop things in different directions so that they cover a large area.
@@ -4778,6 +4780,7 @@ PWN:nausea.n.02	disgust so strong it makes you feel sick
 PWN:nautical.a.01	relating to or involving ships or shipping or navigation or seamen
 PWN:naval_unit.n.01	a military unit that is part of a navy
 PWN:navel.n.01	A scar where the umbilical cord was attached.
+PWN:navigate.v.02	act as the navigator in a car, plane, or vessel and plan, direct, plot the path and position of the conveyance
 PWN:navy.n.01	an organization of military vessels belonging to a country and available for sea warfare
 PWN:near.a.01	not far distant in time or space or degree or circumstances
 PWN:near.r.01	Not far distant in time or space or degree or circumstances.
@@ -4878,6 +4881,7 @@ PWN:note.n.05	a characteristic emotional quality
 PWN:note.v.04	make a written note of
 PWN:nothing.n.01	a quantity of no importance
 PWN:nothingness.n.01	the state of nonexistence
+PWN:notice.v.04	express recognicion of the presence or existence of, or acquaintance with
 PWN:novel.n.01	an extended fictional work in prose; usually in the form of a story
 PWN:november.n.01	The 11th month of the Gregorian calendar.
 PWN:now.r.04	At present; at this time.
@@ -5485,6 +5489,7 @@ PWN:precipice.n.01	A very steep decline, typically found in the mountains or on 
 PWN:precipitate.v.03	fall from clouds
 PWN:precipitation.n.03	the falling to earth of any form of water (rain or snow or hail or sleet or mist)
 PWN:predator.n.02	any animal that lives by preying on other animals
+PWN:predict.v.01	make a prediction about; tell in advance
 PWN:prefer.v.01	like better; value more highly
 PWN:pregnancy.n.01	the state of being pregnant; the period from conception to birth when a woman carries a developing fetus in her uterus
 PWN:pregnant.a.01	Carrying developing offspring within the body.
@@ -5513,6 +5518,7 @@ PWN:pressure.n.01	the force applied to a unit area of surface; measured in pasca
 PWN:prevail.v.03	continue to exist
 PWN:prevent.v.01	keep from happening or arising; make impossible
 PWN:prevent.v.02	To inhibit the occurrence of an event; to stop from doing something or being in a certain state.
+PWN:preview.v.01	watch something before it is released to the general public
 PWN:previous.s.01	just preceding something else in time or order
 PWN:prey.n.02	animal hunted or caught for food
 PWN:price.n.02	The amount of money paid per unit for a good or service.
@@ -5736,6 +5742,7 @@ PWN:ray.n.03	a straight line extending from a point
 PWN:razor.n.01	A bladed tool used for the removal of body hair through the act of shaving.
 PWN:re-create.v.01	create anew
 PWN:reach.v.01	reach a destination, either real or abstract
+PWN:reach.v.04	be in or establish communication with
 PWN:reach.v.06	extend as far as
 PWN:react.v.02	act against or in opposition to
 PWN:reaction.n.03	a bodily process occurring due to the effect of some antecedent stimulus or agent
@@ -6568,6 +6575,7 @@ PWN:spider.n.01	Any predatory silk-producing arachnid of the order Araneae, havi
 PWN:spider_web.n.02	A fine net of threads woven by a spider to catch insects.
 PWN:spike.n.09	a long, thin sharp-pointed implement
 PWN:spill.v.01	Cause liquids to flow over the edge or out of a container.
+PWN:spin.v.01	revolve quickly and repeatedly around one's own axis
 PWN:spin.v.06	To make (yarn) by drawing out, twisting, and winding fibers.
 PWN:spinach.n.01	An important leaf vegetable, grown throughout the temperate regions of the world.
 PWN:spinal_column.n.01	The body part that consists of a row of vertebrae, that support the head and torso and that forms a canal for nerves.
@@ -7329,6 +7337,7 @@ PWN:ununtrium.n.01	Nihonium, the chemical element with atomic number 113 and sym
 PWN:unwind.v.01	reverse the winding or twisting of
 PWN:unwrap.v.02	make known to the public information that was previously known only to a few people or that was meant to be kept a secret
 PWN:up.r.01	Moving to a higher position.
+PWN:update.v.02	bring up to date; supply with recent information
 PWN:upper_bound.n.01	(mathematics) a number equal to or greater than any other number in a given set
 PWN:upset.v.02	cause to lose one's composure
 PWN:uranium.n.01	Uranium, the chemical element with atomic number 92 and symbol U.

--- a/data/id_map.tsv
+++ b/data/id_map.tsv
@@ -512,6 +512,7 @@ PWN:anteater.n.02	02460009-n	181	3-89
 PWN:anteroom.n.01	02715513-n				
 PWN:antibiotic.a.01	02629301-a				
 PWN:antic.n.01	00427580-n				
+PWN:anticipate.v.03	00720808-v				
 PWN:anticipation.n.01	07511080-n				
 PWN:antimony.n.01	14628668-n				
 PWN:antithesis.n.01	13855230-n				
@@ -2319,6 +2320,7 @@ PWN:disorder.n.01	14052403-n
 PWN:disorder.n.03	13972797-n				
 PWN:disorder.v.02	00276373-v				
 PWN:disown.v.02	00757544-v				
+PWN:disparate.s.01	02066836-a				
 PWN:dispatch.n.02	00061290-n				
 PWN:dispatch.v.01	01955127-v				
 PWN:disperse.v.02	02030424-v	3705			
@@ -4778,6 +4780,7 @@ PWN:nausea.n.02	07504111-n
 PWN:nautical.a.01	02889746-a				
 PWN:naval_unit.n.01	08191532-n				
 PWN:navel.n.01	05556595-n	1838	4-43	Nabel::N	553
+PWN:navigate.v.02	01933305-v				
 PWN:navy.n.01	08191701-n				1632
 PWN:near.a.01	00444519-a				
 PWN:near.r.01	00409709-r	1942	12-43	nah::A	2812
@@ -4878,6 +4881,7 @@ PWN:note.n.05	04727694-n
 PWN:note.v.04	01020934-v				
 PWN:nothing.n.01	13740168-n				
 PWN:nothingness.n.01	14455700-n				
+PWN:notice.v.04	01059123-v				
 PWN:novel.n.01	06367879-n				2344
 PWN:november.n.01	15213406-n	2854		November::N	4011
 PWN:now.r.04	00049220-r	1376	14-18	jetzt::ADV	3206
@@ -5485,6 +5489,7 @@ PWN:precipice.n.01	09398677-n	618	1-222
 PWN:precipitate.v.03	02756821-v				
 PWN:precipitation.n.03	11494638-n				
 PWN:predator.n.02	02152740-n				
+PWN:predict.v.01	00917772-v				
 PWN:prefer.v.01	01826498-v				1920
 PWN:pregnancy.n.01	14046202-n				
 PWN:pregnant.a.01	00173220-a	1123	4-73		
@@ -5513,6 +5518,7 @@ PWN:pressure.n.01	11495041-n
 PWN:prevail.v.03	02647497-v				
 PWN:prevent.v.01	02452885-v				3953
 PWN:prevent.v.02	02450505-v	1550	19-59		
+PWN:preview.v.01	02151816-v				
 PWN:previous.s.01	00127137-a				3262
 PWN:prey.n.02	02152881-n				
 PWN:price.n.02	13303315-n	657	11-87	Preis::N	1755
@@ -5736,6 +5742,7 @@ PWN:ray.n.03	13913427-n				3513
 PWN:razor.n.01	04057047-n	151	6-93		1204
 PWN:re-create.v.01	01619354-v				
 PWN:reach.v.01	02020590-v				
+PWN:reach.v.04	00743344-v				
 PWN:reach.v.06	02685665-v				3042
 PWN:react.v.02	02378623-v				
 PWN:reaction.n.03	00859001-n				
@@ -6568,6 +6575,7 @@ PWN:spider.n.01	01772222-n	843	3-818	Spinne::N	948
 PWN:spider_web.n.02	04275363-n	1065	3-819		
 PWN:spike.n.09	04276249-n				3574
 PWN:spill.v.01	01542207-v	3130			3779
+PWN:spin.v.01	02046755-v				
 PWN:spin.v.06	01518772-v	121	6-31		
 PWN:spinach.n.01	11835568-n	975			1096
 PWN:spinal_column.n.01	05588174-n	805	4-191		562
@@ -7329,6 +7337,7 @@ PWN:ununtrium.n.01	14660314-n
 PWN:unwind.v.01	01523654-v				
 PWN:unwrap.v.02	00933821-v				
 PWN:up.r.01	00096333-r	1591	12-08	hinauf::ADV	2901
+PWN:update.v.02	00833546-v				
 PWN:upper_bound.n.01	13903855-n				
 PWN:upset.v.02	01790020-v				
 PWN:uranium.n.01	14660443-n				

--- a/dict/E/eng.tsv
+++ b/dict/E/eng.tsv
@@ -1003,6 +1003,8 @@ PWN:antic.n.01		prank
 PWN:antic.n.01		put-on		
 PWN:antic.n.01		trick		
 PWN:antichrist.n.01		antichrist		
+PWN:anticipate.v.03		anticipate		
+PWN:anticipate.v.03		foresee		
 PWN:anticipation.n.01		anticipation		
 PWN:anticipation.n.01		expectancy		
 PWN:antimony.n.01		antimony		
@@ -5349,7 +5351,6 @@ PWN:detail.n.02		particular
 PWN:detainee.n.01		detainee		
 PWN:detainee.n.01		political detainee		
 PWN:detect.v.01		detect		
-PWN:detect.v.01		discover		
 PWN:detect.v.01		find		
 PWN:detect.v.01		notice		
 PWN:detect.v.01		observe		
@@ -5663,6 +5664,7 @@ PWN:disorder.v.02		disorder
 PWN:disown.v.02		disown		
 PWN:disown.v.02		renounce		
 PWN:disown.v.02		repudiate		
+PWN:disparate.s.01		disparate		
 PWN:dispatch.n.02		despatch		
 PWN:dispatch.n.02		dispatch		
 PWN:dispatch.n.02		shipment		
@@ -7262,6 +7264,7 @@ PWN:find.v.01		chance
 PWN:find.v.01		encounter		
 PWN:find.v.01		find		
 PWN:find.v.01		happen		
+PWN:find.v.03		discover		
 PWN:find.v.03		find		
 PWN:find.v.03		regain		
 PWN:fine-looking.s.01		better-looking		
@@ -11468,6 +11471,8 @@ PWN:navel.n.01		navel
 PWN:navel.n.01		omphalos		
 PWN:navel.n.01		omphalus		
 PWN:navel.n.01		umbilicus		
+PWN:navigate.v.02		navigate		
+PWN:navigate.v.02		wayfind		
 PWN:navy.n.01		naval forces		
 PWN:navy.n.01		navy		
 PWN:near.a.01		close		
@@ -11687,6 +11692,9 @@ PWN:nothingness.n.01		nihility
 PWN:nothingness.n.01		nothingness		
 PWN:nothingness.n.01		nullity		
 PWN:nothingness.n.01		void		
+PWN:notice.v.04		acknowledge		
+PWN:notice.v.04		notice		
+PWN:notice.v.04		recognize		
 PWN:novel.n.01		novel		
 PWN:november.n.01		Nov		
 PWN:november.n.01		November		
@@ -13074,6 +13082,9 @@ PWN:precipitation.n.03		downfall
 PWN:precipitation.n.03		precipitation		
 PWN:predator.n.02		predator		
 PWN:predator.n.02		predatory animal		
+PWN:predict.v.01		anticipate		
+PWN:predict.v.01		foretell		
+PWN:predict.v.01		predict		
 PWN:prefer.v.01		prefer		
 PWN:pregnancy.n.01		gestation		
 PWN:pregnancy.n.01		maternity		
@@ -13132,6 +13143,7 @@ PWN:prevent.v.01		preclude
 PWN:prevent.v.01		prevent		
 PWN:prevent.v.02		keep		
 PWN:prevent.v.02		prevent		:praevenīre
+PWN:preview.v.01		preview		
 PWN:previous.s.01		old		
 PWN:previous.s.01		previous		
 PWN:prey.n.02		prey		
@@ -13702,6 +13714,8 @@ PWN:reach.v.01		gain
 PWN:reach.v.01		hit		
 PWN:reach.v.01		make		
 PWN:reach.v.01		reach		
+PWN:reach.v.04		contact		
+PWN:reach.v.04		reach		
 PWN:reach.v.06		extend to		
 PWN:reach.v.06		reach		
 PWN:reach.v.06		touch		
@@ -15672,6 +15686,8 @@ PWN:spike.n.09		spike
 PWN:spill.v.01		slop		
 PWN:spill.v.01		spill		
 PWN:spill.v.01		splatter		
+PWN:spin.v.01		gyrate		
+PWN:spin.v.01		spin		
 PWN:spin.v.06		spin		
 PWN:spinach.n.01		prickly-seeded spinach		
 PWN:spinach.n.01		spinach		
@@ -17416,6 +17432,8 @@ PWN:up.r.01		up
 PWN:up.r.01		upward		
 PWN:up.r.01		upwardly		
 PWN:up.r.01		upwards		
+PWN:update.v.02		renew		
+PWN:update.v.02		update		
 PWN:upper_bound.n.01		upper bound		
 PWN:upset.v.02		discomfit		
 PWN:upset.v.02		discompose		
@@ -17792,6 +17810,8 @@ PWN:wax.n.01		wax
 PWN:way.n.05		path		
 PWN:way.n.05		way		
 PWN:way.n.05		way of life		
+PWN:way.n.06		path		
+PWN:way.n.06		route		
 PWN:way.n.06		way		
 PWN:way.n.10		way		
 PWN:weak.a.01		weak		

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -94,6 +94,7 @@ PWN:absorb.v.04		asorbe	a.sorb’e
 PWN:accident.n.01		shigu	shigu	zho:事故 (shìgù), yue:事故 (si6gu3), jpn:事故 (jiko), kor:사고 (sago), vie:sự cố + ara: شِقْوَة (šiqwa)
 PWN:accustomed.s.02 		adatik	ada·tik	
 PWN:acetylene.n.01		alkin	alk·in	
+PWN:acknowledgment.n.03		anou	a.nou	
 PWN:actinium.n.01		acinium	acin·ium	eng:actinium, fra:actinium, spa:actinio, por:actínio, rus:актиний, zho:锕 (ā), jpn:アクチニウム, kor:악티늄, vie:actini, hin:एक्टिनियम, ben:অ্যাক্টিনিয়াম, may:aktinium, swa:aktini, ara: اكتنيوم
 PWN:action.n.01		agion	ag·ion	
 PWN:action.n.01		agtion	ag·tion	
@@ -162,6 +163,7 @@ PWN:anonymous.a.01		anonimik	a·no·nim·ik
 PWN:answer.v.01		javab	javab	ara: جَوَاب‎ (jawāb), ben: جواب (jawāb), hin:जवाब (javāb), ben:জবাব (jobab), may:jawab, ful:jaabaade, swa:jibu,jawabu, tur:cevap
 PWN:antibiotic.a.01		antibiotik	anti·bio·tik	
 PWN:antichrist.n.01		antikriste	anti.krist'e	
+PWN:anticipate.v.03		previz	pre.viz	
 PWN:antimony.n.01		stibium	stib·ium	zho:锑 (tī), swa:stibi
 PWN:antithesis.n.01		antites	anti.tes	
 PWN:antithetic.s.01		antitesik	anti.tes·ik	
@@ -375,6 +377,7 @@ PWN:cap.n.02		botel tap	botel tap
 PWN:car.n.01		kar	kar	
 PWN:carbon.n.01		karbe	karb'e	eng:carbon, fra:carbone, spa:carbón, por:carbono, vie:cacbon, hin:कार्बन, ben:কার্বন, may:karbon, swa:kaboni, ara: كربون
 PWN:cardboard.n.01		karton	kart·on	
+PWN:cargo.n.01		kargo	kargo	eng:cargo, fra:cargaison, por:spa:carga, deu:Cargo, may:kargo
 PWN:carrot.n.01		karot	karot	eng:carrot, fra:carotte, deu:Karotte, ful:swa:karoti, hau:karas, amh:ካሮት (karot), may:karot, vie:cà rốt, tam:காரட் (kāraṭ)
 PWN:cashew.n.01		kaju	kaju	fra:cajou, spa:cajú, por:caju, eng:cashew, deu:Kaschu, hin:काजू (kājū), ben:কাজু (kaju), ara: كَاجُو‎ (kājū), ful:kasu, may:gajus, tur:kaşu, jpn:カシュー (kashū), kor:캐슈 (kaesyu)
 PWN:cassava.n.03		manioka	manioka	eng:fra:manioc, spa:por:mandioca, rus:маниока (manioka), kor:마니옥 (maniok), lin:manyɔ́kɔ, kon:mandioko
@@ -413,6 +416,7 @@ PWN:chimpanzee.n.01		chimpanzi	chimpanzi	eng:chimpanzee, spa:chimpancé, por:fra
 PWN:china.n.01		Jung gogia	Jung gog·ia	
 PWN:chlorine.n.01		klor	klor	eng:chlorine, fra:chlore, spa:cloro, por:cloro, rus:хлор, vie:clo, hin:क्लोरीन, ben:ক্লোরিন, may:klor, swa:klorini, ara: كلور
 PWN:chocolate.n.02		chokolat	chokolat	spa:por:eng:chocolate, fra:chocolat, rus:шоколад (šokolad), zho:巧克力 (qiǎokèlì), yue:朱古力 (zyugulik), jpn:チョコレート (chokorēto), kor:초콜렛 (chokollet), hin:चाकलेट (cāklet), ben:চকলেট (côkleṭ), may:cokelat, swa:chokoleti, tur:çikolata, ful:cokolete
+PWN:choose.v.01		chuz	chuz	eng:choose
 PWN:christianity.n.01		kristisme	krist·ism'e	
 PWN:christmas.n.01		kristogen	krist·o·gen	
 PWN:chromium.n.01		kromium	krom·ium	eng:chromium, fra:chrome, spa:cromo, por:crómo, rus:хром, jpn:クロム, kor:크로뮴, vie:crom, hin:क्रोमियम, ben:ক্রোমিয়াম, may:krom, swa:kromi, ara: كروم
@@ -562,6 +566,7 @@ PWN:discipline.n.01		lojia	loj'ia
 PWN:disinter.v.01		exhume	ex.hum'e	
 PWN:disk.n.01		diske	disk'e	eng:tur:disk, fra:disque, spa:por:disco, rus:диск (disk), hin:डिस्क (ḍisk), ben:ডিস্ক (ḑisk), jpn:ディスク (disuku), kor:디스크 (diseukeu)
 PWN:diskette.n.01		diskit	disk·it	
+PWN:disparate.s.01		dispartet	dis.part·et	
 PWN:disperse.v.02		spora	spora	eng:fra:may:tur:diaspora, deu:Diaspora, spa:por:diáspora, rus:диаспора (diaspora), jpn:ディアスポラ (diasupora), kor:디아스포라 (diaseupora)
 PWN:diss.v.01		dusnimiza	dus.nim·iza	
 PWN:distribute.v.04		disdon	dis·don	
@@ -663,6 +668,7 @@ PWN:europium.n.01		europium	europ·ium	eng:europium, fra:europium, spa:europio, 
 PWN:even.r.01		hata	hata	ara: حَتَّى (ḥatta), fas:حَتّی, tur:hau:hatta, swa:hata, ful:haa, spa:hasta, por:até
 PWN:example.n.01		misal	misal	ara:مِثَال, may:misal, tur:misal, fas:مِثال, hin:मिसाल
 PWN:excellent.s.01		top klasik	top klas·ik	
+PWN:excessively.r.01		tu	tu	eng:too
 PWN:exchange.v.01		yek	yek	
 PWN:exclude.v.01		exkluze	ex.kluz'e	
 PWN:exclusive.s.01		exkluziv	ex.kluz·iv	
@@ -719,6 +725,7 @@ PWN:field.n.01		medan	medan	ara: مَيْدَان‎ (maydān), fas:(meydan), hi
 PWN:field_hockey.n.01		hoki	hoki	
 PWN:fight.v.03		jihad	jihad	
 PWN:filming.n.01		kinografia	kin·o·graf·ia	
+PWN:find.v.03		eureka	eureka	eng:eureka, spa:eureka, rus:э́врика (évrika), tur:evreka, cmn:尤里卡, jpn:ユーレカ
 PWN:fire.n.01		piro	pir’o	eng:deu:fra:pyro-, spa:por:tur:piro-, rus:пиро- (piro-)
 PWN:fire.n.03 		flem	flem	eng:flame, fra:flamme, ita:fiamma, spa:inflamable, por:inflamável + zho:炎 (yán), yue:炎 (jim4), kor:염 (yeom), vie:viêm
 PWN:fist.n.01		kuen	kuen	zho:拳 (quán), yue:拳 (kyun4), vie:quyền, jpn:拳 (ken), kor:권 (gwon)
@@ -853,6 +860,7 @@ PWN:hertz.n.01		herze	herz'e
 PWN:heuristic.a.01		heuristik	heur·ist·ik	
 PWN:hiccup.n.01		hik	hik	eng:hiccup, rus:икота (ikota), hin:हीक (hīk), jpn:ヒック (hikku)
 PWN:hiccup.v.01		hik	hik	
+PWN:hide.v.01		sir	sir	
 PWN:high.a.02		hai	hai	eng:high
 PWN:hinduism.n.01		hindisme	hind·ism'e	
 PWN:hint.n.01		anshi	anshi	zho:暗示 (ànshì), yue:暗示 (am3si6), jpn:暗示 (anji), kor:암시 (amsi)
@@ -1033,6 +1041,7 @@ PWN:little.r.01		kam	kam	deu:kaum + fas: کم‎ (kam), hin:कम (kam), ben:�
 PWN:little_sister.n.01		jun sis	jun sis	
 PWN:liver.n.01		gan	gan	zho:肝 (gān), yue:肝 (gon1), wuu:肝 (koe1), kor:간 (gan), jpn:肝臓 (kanzō), vie:gan + swa:ini
 PWN:lizard.n.01		saur	saur	ell:σαύρα (saura), eng:-saur, fra:-saure, spa:-saurio, por:-sauro, rus:-завр (-zavr), hin:ben: may:-saur(us) + hin:सरट (saraṭ)
+PWN:load.v.02		kargo	kargo	
 PWN:location.n.01		plas	plas	eng:fra:place, deu:Platz
 PWN:loin.n.02		lumbe	lumb'e	eng:lumbus, fra:lombes, spa:lomo, por:lombo
 PWN:long.a.01		long duran	long dura·n	
@@ -1070,6 +1079,7 @@ PWN:mammalia.n.01		mamalia	mam·al·ia
 PWN:man.n.06		vir	vir	
 PWN:manganese.n.01		mangan	mangan	eng:manganese, fra:manganèse, spa:manganeso, por:manganésio, rus:марганец, zho:锰 (měng), jpn:マンガン, kor:망가니즈, vie:mangan, hin:मैंगनीज, ben:ম্যাঙ্গানিজ, may:manggan, swa:manganisi, ara: منجنيز
 PWN:mango.n.01		mango	mango	mal:മാങ്ങ (māṅṅa), eng:spa:tur:mango, por:manga, rus:манго (mango), may:mangga, jpn:マンゴー (mangō), kor:망고 (manggo), hau:mangora, ful:mannguure
+PWN:manner.n.01		vei	vei	eng:way, deu:Weg
 PWN:many.a.01		poli	poli	ell:πολλοί (polloí), eng:fra:deu:poly-, spa:por:poli-, rus:поли- (poli-) + tam:பல (pala)
 PWN:map.n.01		harte	hart'e	eng:chart, fra:carte, spa:por:carta, rus:карта (karta), ara: خَرِيطَة‎ (ḵarīṭa), fas: خریطه (xarite), tur:harita
 PWN:mapmaking.n.01		hartografia	kart·o·graf·ia	
@@ -1171,6 +1181,7 @@ PWN:naturalistic.s.01		hakikik	hak·ik·ik
 PWN:nature.n.01		natur	nat·ur	
 PWN:nature.n.01 		tabia	tab.ia	
 PWN:nautical.a.01		nautik	nau·tik	
+PWN:navigate.v.02		veieureka	vei·eureka	
 PWN:near.a.01		karib	karib	ara: قَرِيب (qarīb), fas: قریب (qarib), hin:क़रीब (qarīb), swa:karibu, tur:karip
 PWN:necromancy.n.02		nekromantia	nekr·o·mant·ia	
 PWN:negative.a.01		negativ	nega·tiv	
@@ -1195,6 +1206,7 @@ PWN:normal.a.01		normal	norm·al
 PWN:north.n.03		norde	nord'e	eng:north, spa:por:norte, deu:Nord, fra:nord, rus:норд (nord)
 PWN:nose.n.01		naze	naz'e	eng:nose, spa:por:nariz, deu:Nase, rus:нос (nos), fas:نس‎ (nos), hin:नासिका (nāsikā), ben:নাক (nak), tam:நாசி (nāsi)
 PWN:nostalgia.n.01		nostalgia	nost·alg·ia	
+PWN:notice.v.04		anou	a.nou	
 PWN:november.n.01		mes ten un	mes ten un	
 PWN:now.r.04		nun	nun	eng:now, deu:nun, dan:sve:nu, fas: اکنون (aknun), pnb:ਹੁਣ (huṇ)
 PWN:nudism.n.01		nudisme	nud·ism'e	
@@ -1234,6 +1246,7 @@ PWN:oxygen.n.01		oxe	ox'e	eng:oxygen, fra:oxygène, spa:oxígeno, por:oxigénio,
 PWN:pack.v.01		pake	pak'e	
 PWN:package.n.01		pakaje	pak·aj'e	
 PWN:package.n.01		paket	pak·et	
+PWN:page.n.01		pagina	pagina	eng:paginate, por:spa:página, fra:page
 PWN:pain.n.03		alge	alg'e	eng:por:spa:-algia, fra:deu:-algie, rus:-альгия (-alʹgiya) + jpn:ノスタルジー (nosutarujī), fas: نوستالژی‎ (nostâlži), tur:nostalji
 PWN:painful.a.01		algik	alg·ik	
 PWN:paint.n.01		pente	pent'e	
@@ -1347,10 +1360,12 @@ PWN:praise.v.01		eulogiza	eu.log·iza
 PWN:praseodymium.n.01		prazedimium	prazedim·ium	eng:praseodymium, fra:praséodyme, spa:praseodimio, por:praseodímio, rus:празеодим, jpn:プラセオジム, kor:프라세오디뮴, vie:prazeođim, hin:प्रासियोडाइमियम, ben:প্র্যাসেওডিমিয়াম, may:praseodinium, swa:praseodimi, ara: براسوديميوم
 PWN:pray.v.01		dua	dua	
 PWN:prayer.n.01		dua	dua	ara: دُعَاء‏  (duʿāʾ), fas: دعا (do'â), hin:दुआ (duā), ben:দুয়া (dua), may:doa, swa:tur:dua, hau:àddu'ā̀, ful:du'aade, yor:àdúrà + zho:祷 (dǎo), jpn:禱 (tō), kor:도 (do)
+PWN:predict.v.01		predit	pre.dit	
 PWN:prepose.v.01		prepozi	pre.pozi	
 PWN:present.a.01		zaitik	zai·tik	
 PWN:press.v.01		pres	pres	
 PWN:prevail.v.03		persiste	per.sist'e	
+PWN:preview.v.01		previz	pre.viz	
 PWN:previous.s.01		pretik	pre·tik	
 PWN:print.v.04		impres	im.pres	
 PWN:printer.n.02		impreser	im.pres·er	
@@ -1393,6 +1408,7 @@ PWN:rapid.s.02		rapid	rap·id	eng:rapid, fra:rapide, spa:por:rápido, ned:rap
 PWN:rare.s.04		nadir	nadir	ara: نَادِر‎ (nādir), fas: نادر (nâder), hin:नादिर (nādir), swa:nadra, tur:nadir, hau:nadiri
 PWN:ravioli.n.01		giau	giau	zho:饺 (jiǎo), yue:餃 (gaau2), jpn:餃子 (gyōza), tha:เกี๊ยว (gíao)
 PWN:razor.n.01		razer	raz·er	
+PWN:reach.v.04		kontakte	kon.takt'e	
 PWN:real.a.01		hakik	hak·ik	
 PWN:reality.n.03		hakikia	hak·ik·ia	
 PWN:reasoning.n.01		ration	rat·ion	
@@ -1418,6 +1434,7 @@ PWN:resistance.n.01		resistion	re.sist·ion
 PWN:resistor.n.01		resistor	re.sist·or	
 PWN:restaurant.n.01		restauran	re.staura·n	
 PWN:revolution.n.01		revolution	re.volu·tion	
+PWN:revolve.v.01		rota	rota	eng:rotate, por:spa:rotar, rus:ро́тор (rótor)
 PWN:rhenium.n.01		renium	ren·ium	eng:rhenium, fra:rhénium, spa:renio, por:rénio, rus:рений, zho:铼 (lái), jpn:レニウム, kor:레늄, vie:reni, hin:रेनियम, ben:রেনিয়াম, may:renium, swa:reni, ara: رنيوم
 PWN:rhinal.a.01		nazal	naz·al	
 PWN:rhodium.n.01		rodium	rod·ium	eng:rhodium, fra:rhodium, spa:rodio, por:ródio, rus:родий, jpn:ロジウム, kor:로듐, vie:rođi, hin:रोडियम, ben:রোডিয়াম, may:rodium, swa:rodi, ara: روديوم
@@ -1453,9 +1470,11 @@ PWN:sandwich.n.01		sanviche	sanvich'e	eng:fra:spa:sandwich, por:sanduíche, rus:
 PWN:satan.n.01		shatan	shatan	heb: שָׂטָן‎ (śaṭan), ara: شيطان (šayṭān), eng:fra:deu:vie:Satan, spa:Satán, por:Satã, rus:Сатана (Satana), zho:撒但 (Sādàn), yue:撒但 (saat3daan6), kor:사탄 (satan), jpn:サタン (satan), hin:शैतान (śaitān), ben:শয়তান (śoẏtan), tam:சயித்தான் (cayittāṉ), may:Setan, tur:şeytan, swa:Shetani, hau:shaiɗan
 PWN:satanic.a.02		shatanik	shatan·ik	
 PWN:sausage.n.01		sosis	sosis	fra:saucisse, tur:may:sosis, fas:(sosis), rus:сосиска  (sosiska), jpn:ソーセージ (sosēji), hin:सॉसेज (sosej), ben:সসেজ (sôsej), eng:sausage
+PWN:save.v.02		hazin	hazin	
 PWN:saw.n.02		shara	shara	alb:sharrë + spa:sierra, por:serra + आरा (ārā) + ara: مِنْشَار‎ (minšār), fas: منشار‎ (menšâr)
 PWN:scandium.n.01		skandium	skand·ium	eng:scandium, fra:scandium, spa:escandio, por:escândio, rus:скандий, zho:钪 (kàng), jpn:スカンジウム, kor:스칸듐, vie:scandi, hin:स्काण्डियम, ben:স্ক্যান্ডিয়াম, may:skandium, swa:skandi, ara: سكانديوم
 PWN:scarf.n.01		shol	shol	eng:shawl, deu:Schal, fra:châle, por:xaile, spa:chal, rus:шаль (šal), fas: شال (šâl), hin:शाल (śāl), ben:শাল (śal), ara: شَال‎ (šāl), may:syal, tur:şal, jpn:ショール (shōru), kor:숄 (syol)
+PWN:scatter.v.03		disparte	dis.part'e	
 PWN:scientific.a.01		lojiatik	loj·ia·tik	
 PWN:scissors.n.01		makas	makas	ara: مَقَص‎ (maqaṣ), tur:makas, swa:mkasi, orm:maqasii, hau:almakashi, yor:àlùmogàjí, ful:almakaci
 PWN:scorpion.n.03		akrab	akrab	ara: عَقْرَب (ʿaqrab), tur:akrep, spa:alacrán, por:lacrau, tgl:alakdan, hin:अकरब (akrab) + may:Akrab, swa:Akarabu
@@ -1468,6 +1487,7 @@ PWN:season.n.02		mosim	mosim
 PWN:second.n.01		sekun	sekun	eng:second, spa:por:segundo, rus:секунда (sekunda), swa:sekunde, hin:सैकण्ड (saikaṇḍ), ben:সেকেন্ড (śekenḍ)
 PWN:secret.s.01		sir	sir	ara: سِرّ (sirr), hin:सेर (ser), may:sir, swa:siri, hau:asiri, ful:sirri, yor:àṣírí, tur:sır, fas:(serr)
 PWN:see.v.01		si	si	eng:see, deu:sehen, zho:视 (shì), yue:視 (si6), jpn:視 (shi), kor:시 (si), vie:thị
+PWN:see.v.01		viz	viz	eng:fra:vision, por:visão, spa:visión + swa:televisheni, may:televisyen, jpn:テレビジョン (terebijon)
 PWN:seed.n.02		sem	sem	fra:semence, por:semente, spa:semilla, rus:семя (semya), eng:semen
 PWN:selenium.n.01		selenium	selen·ium	eng:selenium, fra:sélénium, spa:selenio, por:selénio, rus:селен, zho:硒 (xī), jpn:セレン, kor:셀렌, vie:selen, hin:सेलेनियम, ben:সেলেনিয়াম, may:selenium, swa:seleni, ara: سيلينيوم
 PWN:semaphore.n.01		semafer	sema·fer	
@@ -1494,6 +1514,8 @@ PWN:ship.n.01		nau	nau	fra:navire, spa:nave, por:navio, fas: ناو‎ (nâv), h
 PWN:shipwreck.n.03		naufrage	nau·frag’e	
 PWN:shirt.n.01		sherte	shert'e	eng:shirt, deu:T-Shirt, fra:por:T-shirt, fas: تی‌شِرْت (ti-šert), hin:टी-शर्ट (ṭī-śarṭ), ben:শার্ট (śarṭo), tur:tişört, zho:T恤衫 (tī-xùshān), yue:恤衫 (seot1 saam1), jpn:シャツ (shatsu), kor:셔츠 (syeocheu), tam:சட்டை (caṭṭai), ara: تِي شِيرْت (tī šīrt), swa:shati, yor:ṣẹ́ẹ̀tì
 PWN:shoe.n.01		bot	bot	hin:बूट (būṭ), pol:but, cze:bota, yor:bata + eng:boot, fra:botte, spa:por:bota, rus:ботинок (botinok), pol:may:but, fas: بوت‎ (but), ara: بوت‎ (bōt), jpn:ブーツ (būtsu), swa:buti
+PWN:short.a.01		korte	kort'e	eng:curt, por:curto, spa:corto, fra:court, deu:Kürze
+PWN:short.a.02		korte	kort'e	
 PWN:show.v.01		shou	shou	eng:deu:fra:spa:por:show, rus:шоу (šou), tur:şov, swa:shoo, kor:쇼 (syo), jpn:ショー (shō), zho:秀 (xiù), yue:騷 (sou1)
 PWN:shower.n.01		dush	dush	fra:douche, spa:por:ducha, deu:Dusche, rus:душ (duš), ara: دوش (dūš), may:dus, tur:duş
 PWN:shrink.v.03		dekres	de.kres	
@@ -1547,6 +1569,7 @@ PWN:south.n.03		sud	sud	deu:Süden, fra:sud, spa:sur, por:sul, eng:south, rus:з
 PWN:space.n.01		kosme	kosm'e	eng:fra:spa:cosmos, deu:Kosmos, por:cosmo, rus:космос (kosmos), tur:kozmo-
 PWN:spain.n.01		Espania	Espan·ia	
 PWN:spider.n.01		aran	aran	fra:araignee, por:aranha, spa:araña, eng:arachnid, deu:Arachno-, rus:арахнофо- (arakhno-), tur:arakno-, tam:அராக்கினிட் (arākkiṉiṭ), may:araknid
+PWN:spin.v.01		rota	rota	
 PWN:spinach.n.01		spanak	spanak	
 PWN:spit.v.01		tuk	tuk	hin: थूकना (thūknā), zho: 吐 (tǔ), yue:吐 (tou3), tur:tükürmek, ful:tuutde
 PWN:sponge.n.01		sponje	sponj'e	eng:sponge, spa:por:esponja, ara:إسفنج (ʾisfanj), fas:اسفنج‎ (esfanj), hin:स्पंज (spanja), jpn:スポンジ (suponji), may:spon, swa:sponji
@@ -1565,6 +1588,7 @@ PWN:starship.n.01		astronau	astr·o·nau
 PWN:starship.n.01		kosmonau	kosm·o·nau	
 PWN:state.n.02		hal	hal	ara:حال (ḥāl), hin:हालत (hālat), swa:hau:hali, ful:haala; alhaali, tur:hâl
 PWN:state.n.04		gogia	gog·ia	zho:国家 (guójiā), yue:國家 (gwok3 gaa1), jpn:国 (koku); 国家 (kokka), kor:국가 (gukga), vie:quốc gia
+PWN:state.v.01		dit	dit	eng:diction, fra:dire, por:dizer, spa:decir
 PWN:state.v.01		log	log	ell:λόγος (logos), eng:fra:-logue, spa:por:-logo, rus:-лог (-log) + ara: لُغَة‎ (luğa), fas: لغت‎ (loğat), hin:लुग़त (luġat), swa:lugha, tur:lügat, may:logat
 PWN:static.s.03		statik	sta·tik	
 PWN:steam.n.01		vapur	vap·ur	eng:vapor, fra:vapeur, spa:por:vapor + (vaper) tur:vapur, ara: بابور‎ (bābōr), hau:babur
@@ -1633,6 +1657,7 @@ PWN:tea.n.01		cha	cha	zho:茶 (chá), yue:茶 (caa4), jpn:茶 (cha), kor:차 (ch
 PWN:team.n.01		tim	tim	eng:team, deu:Team, swa:timu, fas: تیم‎ (tim), hin:टीम (ṭīm), ben:টীম (ṭim), jpn:チーム (chīmu), kor:팀 (tim)
 PWN:teapot.n.01		cha pote	cha pot'e	
 PWN:tear.n.01		ain sui	ain sui	tam:கண்ணீர் (kaṇṇīr), mal:കണ്ണുനീർ (kaṇṇunīr), tel:(kannīru), kor:눈물 (nunmul), vie:nước mắt, may:air mata, tha:น้ำตา
+PWN:tear.v.01		frag	frag	
 PWN:teashop.n.01		chakan	cha·kan	
 PWN:technetium.n.01		tehnetium	tehn·et·ium	eng:technetium, fra:technétium, spa:tecnetio, por:tecnécio, rus:технеций, zho:锝 (dé), jpn:テクネチウム, kor:테크네튬, vie:tecnexi, hin:टेक्निशियम, ben:টেকনিসিয়াম, may:teknetium, swa:tekineti, ara: تكنيتيوم
 PWN:technology.n.01		teknolojia	tekn·o·loj·ia	
@@ -1666,6 +1691,7 @@ PWN:there.r.01		der	der
 PWN:therefore.r.01		a sabab of da	a sabab of da	
 PWN:thermometer.n.01		termometrer	term·o·metr·er	
 PWN:thesis.n.01		tes	tes	eng:thesis, deu:These, fra:thèse, spa:tesis, por:tese, rus:тезис (tezis), fas: تز‎ (tez), tur:tez, jpn:テーゼ (tēze), kor:테제 (teje)
+PWN:thin.a.01		bok	bok	zho:博 (báo), jpn:薄 (haku), kor:박 (bak)
 PWN:thing.n.09		ting	ting	eng:thing, deu:Ding
 PWN:think.v.11		fikre	fikr'e	ara: فِكْر (fikr), swa:fikiri, tur:fikir, fas: فکر‎ (fekr), hin:फ़िक्र (fikr), ben:ফিকির (fikir), may:pikir
 PWN:thorium.n.01		torium	tor·ium	eng:thorium, fra:thorium, spa:torio, por:tório, rus:торий, zho:钍 (tǔ), jpn:トリウム, kor:토륨, vie:thori, hin:थोरियम, ben:থোরিয়াম, may:torium, swa:thori, ara: ثوريوم
@@ -1696,6 +1722,8 @@ PWN:top.a.01		top	top
 PWN:top.n.01 		top	top	
 PWN:top.n.02		top	top	eng:fra:top, por:spa:topo, vie:tốp, deu:top, rus:топ- (top-)
 PWN:toucan.n.01		tukan	tukan	eng:fra:toucan, deu:Tukan, spa:tucán, por:tucano, rus:тукан (tukan), fas: توکان (tukân), ara: طُوقَان (ṭūqān),tam:தூக்கான் (tūkkāṉ), may:tur:tukan, zho:鵎鵼 (tuǒkōng), vie:tucăng
+PWN:touch.v.05		kontakte	kon.takt'e	
+PWN:touch.v.05		takte	takt'e	eng:tactile, fra:tact, por:tato, spa:tacto
 PWN:towel.n.01		tual	tual	eng:towel, fra:touaille, spa:toalla, por:toalha, jpn:タオル (taoru), kor:타월 (tawol), hin:तौलिया (tauliyā), ben:তোয়ালে (toẏale), tam:துவாலை (tuvālai), may:tuala + deu:Toilette, rus:туалет (tualet), ara: تْوَالِيتّ‎ (twālitt), fas: توالت‎ (tuâlet), vie:toa-lét, tur:tuvalet
 PWN:town.n.01		pol	pol	eng:spa:-polis, deu:fra:por:-pole, rus:-поль (-pol'), may:tur:-pol
 PWN:toxin.n.01		biotoxe	bio·tox'e	
@@ -1714,6 +1742,7 @@ PWN:trick.n.01		truk	truk	eng:trick, deu:Trick, fra:truc, spa:truco, por:truque,
 PWN:true.a.01		ver	ver	
 PWN:trust.v.01		amen	amen	
 PWN:truth.n.01		hakita	hak·ita	
+PWN:try.v.01		teste	test'e	eng:test, por:teste, spa:test, rus:тест (test), tur:test, fas:تست (test), jpn:テスト (tesuto)
 PWN:tube.n.01		tube	tub'e	spa:por:tubo, eng:fra:tube, jpn:チューブ (chūbu), zul:ithumbu, xho:íthumbu
 PWN:tundra.n.01		tundra	tundra	eng:spa:por:tur:tundra, rus:тундра (tundra), ara:تندرا‎ (tundrā), hin:टुंड्रा (ṭuṇḍrā), jpn:ツンドラ (tsundora)
 PWN:tungsten.n.01		volfram	volfram	eng:wolfram, spa:wolframio, rus:вольфрам, zho:钨 (wū), vie:vonfam, may:wolfram, swa:wolframi
@@ -1735,6 +1764,7 @@ PWN:ununpentium.n.01		moskovium	moskov·ium	eng:fra:moscovium, spa:moscovio, por
 PWN:ununquadium.n.01		flerovium	flerov·ium	eng:may:flerovium, fra:flérovium, spa:flerovio, por:fleróvio, rus:флеровий, zho: (fū), jpn:フレロビウム, kor:플레로븀, vie:flerovi, swa:flerovi
 PWN:ununtrium.n.01		niponium	nipon·ium	eng:fra:may:nihonium, spa:nihonio, por:nihonium, rus:нихоний, jpn:ニホニウム, kor:우눈트륨, vie:swa:nihoni
 PWN:unwind.v.01		devolu	de.volu	
+PWN:update.v.02		nov	nov	
 PWN:uranium.n.01		uranium	uran·ium	eng:uranium, fra:uranium, spa:uranio, por:urânio, rus:уран, jpn:ウラン, kor:우라늄, vie:urani (uran), hin:युरेनियम, ben:ইউরেনিয়াম, may:uranium, swa:urani, ara: يورانيوم
 PWN:urban.a.01		polik	pol·ik	
 PWN:urine.n.01		pisha	pisha	eng:piss, deu:Pisse, fra:pisse, fas:پیشاب (pišâb), hin:पेशाब (pešāb), ben:পেশাব (peśab), may:pipis
@@ -1763,6 +1793,7 @@ PWN:washup.n.01		hamam	hamam	ara: حمام (ḥammām), tur:hamam, fas: حمام
 PWN:water.n.06		sui	sui	zho:水 (shuǐ), yue:水 (seoi2), jpn:水 (sui), kor:수 (su), vie:thuỷ + tur:su
 PWN:watermelon.n.01		arbuz	arbuz	rus:арбуз (arbuz), pol:arbuz, tur:karpuz, fas: تربز (tarboz), hin:तरबूज़ (tarbūz), ben:তরমুজ (tôrmuj), tam:தர்பூசணி (tarpūcaṇi)
 PWN:wax.n.01		mum	mum	hin:मोम (mom), ben:মোম (mom), fas: موم‎ (mum), tur:mum + ara: مومياء (mumiya), eng:mummy, fra:momie, spa:momia, por:múmia, rus:мумия (mumiya), zho:木乃伊 (mùnǎiyī), may:mumia
+PWN:way.n.06		vei	vei	
 PWN:web_log.n.01		blog	blog	eng:fra:spa:por:tur:may:blog, rus:блог (blog), ara:بلوغ‎ (blūḡ), hin:ब्लॉग (blŏg), zho:博客 (bókè), jpn:ブログ (burogu)
 PWN:west.n.02		veste	vest'e	eng:west, deu:West, fra:ouest, spa:por:oeste, rus:вест (vest)
 PWN:wet.a.01		nem	nem	fas: نم‎ (nam), hin:नम (nam), ben:নম (nom), tur:nem, vie:ẩm

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -1692,7 +1692,7 @@ PWN:there.r.01		der	der
 PWN:therefore.r.01		a sabab of da	a sabab of da	
 PWN:thermometer.n.01		termometrer	term·o·metr·er	
 PWN:thesis.n.01		tes	tes	eng:thesis, deu:These, fra:thèse, spa:tesis, por:tese, rus:тезис (tezis), fas: تز‎ (tez), tur:tez, jpn:テーゼ (tēze), kor:테제 (teje)
-PWN:thin.a.01		bok	bok	zho:薄 (bó), jpn:薄 (haku), kor:박 (bak)
+PWN:thin.a.01		tenu	tenu	eng:tenuous, fra:ténu, por:tênue, spa:tenue, deu:dünn, rus:тонкий (tonkii), fas: تنک (tonok), san:तनु (tanu)
 PWN:thing.n.09		ting	ting	eng:thing, deu:Ding
 PWN:think.v.11		fikre	fikr'e	ara: فِكْر (fikr), swa:fikiri, tur:fikir, fas: فکر‎ (fekr), hin:फ़िक्र (fikr), ben:ফিকির (fikir), may:pikir
 PWN:thorium.n.01		torium	tor·ium	eng:thorium, fra:thorium, spa:torio, por:tório, rus:торий, zho:钍 (tǔ), jpn:トリウム, kor:토륨, vie:thori, hin:थोरियम, ben:থোরিয়াম, may:torium, swa:thori, ara: ثوريوم

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -1181,7 +1181,7 @@ PWN:naturalistic.s.01		hakikik	hak·ik·ik
 PWN:nature.n.01		natur	nat·ur	
 PWN:nature.n.01 		tabia	tab.ia	
 PWN:nautical.a.01		nautik	nau·tik	
-PWN:navigate.v.02		veieureka	vei·eureka	
+PWN:navigate.v.02		veiheure	vei·heur’e	
 PWN:near.a.01		karib	karib	ara: قَرِيب (qarīb), fas: قریب (qarib), hin:क़रीब (qarīb), swa:karibu, tur:karip
 PWN:necromancy.n.02		nekromantia	nekr·o·mant·ia	
 PWN:negative.a.01		negativ	nega·tiv	

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -668,7 +668,7 @@ PWN:europium.n.01		europium	europ·ium	eng:europium, fra:europium, spa:europio, 
 PWN:even.r.01		hata	hata	ara: حَتَّى (ḥatta), fas:حَتّی, tur:hau:hatta, swa:hata, ful:haa, spa:hasta, por:até
 PWN:example.n.01		misal	misal	ara:مِثَال, may:misal, tur:misal, fas:مِثال, hin:मिसाल
 PWN:excellent.s.01		top klasik	top klas·ik	
-PWN:excessively.r.01		tu	tu	eng:too
+PWN:excessively.r.01		tai	tai	cmn:太 (tài)
 PWN:exchange.v.01		yek	yek	
 PWN:exclude.v.01		exkluze	ex.kluz'e	
 PWN:exclusive.s.01		exkluziv	ex.kluz·iv	
@@ -725,7 +725,7 @@ PWN:field.n.01		medan	medan	ara: مَيْدَان‎ (maydān), fas:(meydan), hi
 PWN:field_hockey.n.01		hoki	hoki	
 PWN:fight.v.03		jihad	jihad	
 PWN:filming.n.01		kinografia	kin·o·graf·ia	
-PWN:find.v.03		eureka	eureka	eng:eureka, spa:eureka, rus:э́врика (évrika), tur:evreka, cmn:尤里卡, jpn:ユーレカ
+PWN:find.v.03		heure	heur’e	
 PWN:fire.n.01		piro	pir’o	eng:deu:fra:pyro-, spa:por:tur:piro-, rus:пиро- (piro-)
 PWN:fire.n.03 		flem	flem	eng:flame, fra:flamme, ita:fiamma, spa:inflamable, por:inflamável + zho:炎 (yán), yue:炎 (jim4), kor:염 (yeom), vie:viêm
 PWN:fist.n.01		kuen	kuen	zho:拳 (quán), yue:拳 (kyun4), vie:quyền, jpn:拳 (ken), kor:권 (gwon)

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -566,7 +566,7 @@ PWN:discipline.n.01		lojia	loj'ia
 PWN:disinter.v.01		exhume	ex.hum'e	
 PWN:disk.n.01		diske	disk'e	eng:tur:disk, fra:disque, spa:por:disco, rus:диск (disk), hin:डिस्क (ḍisk), ben:ডিস্ক (ḑisk), jpn:ディスク (disuku), kor:디스크 (diseukeu)
 PWN:diskette.n.01		diskit	disk·it	
-PWN:disparate.s.01		dispartet	dis.part·et	
+PWN:disparate.s.01		disparet	dis.par·et	
 PWN:disperse.v.02		spora	spora	eng:fra:may:tur:diaspora, deu:Diaspora, spa:por:diáspora, rus:диаспора (diaspora), jpn:ディアスポラ (diasupora), kor:디아스포라 (diaseupora)
 PWN:diss.v.01		dusnimiza	dus.nim·iza	
 PWN:distribute.v.04		disdon	dis·don	
@@ -668,7 +668,7 @@ PWN:europium.n.01		europium	europ·ium	eng:europium, fra:europium, spa:europio, 
 PWN:even.r.01		hata	hata	ara: حَتَّى (ḥatta), fas:حَتّی, tur:hau:hatta, swa:hata, ful:haa, spa:hasta, por:até
 PWN:example.n.01		misal	misal	ara:مِثَال, may:misal, tur:misal, fas:مِثال, hin:मिसाल
 PWN:excellent.s.01		top klasik	top klas·ik	
-PWN:excessively.r.01		tai	tai	cmn:太 (tài)
+PWN:excessively.r.01		tai	tai	
 PWN:exchange.v.01		yek	yek	
 PWN:exclude.v.01		exkluze	ex.kluz'e	
 PWN:exclusive.s.01		exkluziv	ex.kluz·iv	
@@ -1474,7 +1474,7 @@ PWN:save.v.02		hazin	hazin
 PWN:saw.n.02		shara	shara	alb:sharrë + spa:sierra, por:serra + आरा (ārā) + ara: مِنْشَار‎ (minšār), fas: منشار‎ (menšâr)
 PWN:scandium.n.01		skandium	skand·ium	eng:scandium, fra:scandium, spa:escandio, por:escândio, rus:скандий, zho:钪 (kàng), jpn:スカンジウム, kor:스칸듐, vie:scandi, hin:स्काण्डियम, ben:স্ক্যান্ডিয়াম, may:skandium, swa:skandi, ara: سكانديوم
 PWN:scarf.n.01		shol	shol	eng:shawl, deu:Schal, fra:châle, por:xaile, spa:chal, rus:шаль (šal), fas: شال (šâl), hin:शाल (śāl), ben:শাল (śal), ara: شَال‎ (šāl), may:syal, tur:şal, jpn:ショール (shōru), kor:숄 (syol)
-PWN:scatter.v.03		disparte	dis.part'e	
+PWN:scatter.v.03		dispar	dis.par	
 PWN:scientific.a.01		lojiatik	loj·ia·tik	
 PWN:scissors.n.01		makas	makas	ara: مَقَص‎ (maqaṣ), tur:makas, swa:mkasi, orm:maqasii, hau:almakashi, yor:àlùmogàjí, ful:almakaci
 PWN:scorpion.n.03		akrab	akrab	ara: عَقْرَب (ʿaqrab), tur:akrep, spa:alacrán, por:lacrau, tgl:alakdan, hin:अकरब (akrab) + may:Akrab, swa:Akarabu
@@ -1675,6 +1675,7 @@ PWN:tent.n.01		hema	hema	ara: خَيْمَة‎ (xayma), spa:jaima, fas: خیم�
 PWN:tepee.n.01		tipi	tipi	deu:Tipi, eng:fra:spa:por:may:tur:tipi, hin:टीपी (tipi), zho:梯皮 (tīpí), jpn:ティピー (tipi), kor:티피 (tipi)
 PWN:terbium.n.01		terbium	terb·ium	eng:terbium, fra:terbium, spa:terbio, por:térbio, rus:тербий, zho:铽 (tè), jpn:テルビウム, kor:테르븀, 2터븀, vie:tecbi, hin:टर्बियम, ben:টার্বিয়াম, may:terbium, swa:taribi, ara: تربيوم
 PWN:tesla.n.01		tesla	tesla	
+PWN:test.v.01		teste	test'e	eng:test, por:teste, spa:test, rus:тест (test), tur:test, fas:تست (test), jpn:テスト (tesuto)
 PWN:thallium.n.01		talium	tal·ium	eng:thallium, fra:thallium, spa:talio, por:tálio, rus:таллий, zho:铊 (tā), jpn:タリウム, kor:탈륨, vie:tali, hin:थैलियम, ben:থ্যালিয়াম, may:tallium, swa:tali, ara: ثاليوم
 PWN:thank.v.01		danke	dank'e	eng:thank, deu:danken, pol:dziękować, ukr:дякувати (dyakuvati), hin:थैंक्स (tha͠iks), zho:三Q (sān kiù), jpn:サンキュー (sankyū), kor:땡큐 (ttaengkyu)
 PWN:theism.n.01		deisme	de·ism'e	
@@ -1691,7 +1692,7 @@ PWN:there.r.01		der	der
 PWN:therefore.r.01		a sabab of da	a sabab of da	
 PWN:thermometer.n.01		termometrer	term·o·metr·er	
 PWN:thesis.n.01		tes	tes	eng:thesis, deu:These, fra:thèse, spa:tesis, por:tese, rus:тезис (tezis), fas: تز‎ (tez), tur:tez, jpn:テーゼ (tēze), kor:테제 (teje)
-PWN:thin.a.01		bok	bok	zho:博 (báo), jpn:薄 (haku), kor:박 (bak)
+PWN:thin.a.01		bok	bok	zho:薄 (bó), jpn:薄 (haku), kor:박 (bak)
 PWN:thing.n.09		ting	ting	eng:thing, deu:Ding
 PWN:think.v.11		fikre	fikr'e	ara: فِكْر (fikr), swa:fikiri, tur:fikir, fas: فکر‎ (fekr), hin:फ़िक्र (fikr), ben:ফিকির (fikir), may:pikir
 PWN:thorium.n.01		torium	tor·ium	eng:thorium, fra:thorium, spa:torio, por:tório, rus:торий, zho:钍 (tǔ), jpn:トリウム, kor:토륨, vie:thori, hin:थोरियम, ben:থোরিয়াম, may:torium, swa:thori, ara: ثوريوم
@@ -1722,8 +1723,8 @@ PWN:top.a.01		top	top
 PWN:top.n.01 		top	top	
 PWN:top.n.02		top	top	eng:fra:top, por:spa:topo, vie:tốp, deu:top, rus:топ- (top-)
 PWN:toucan.n.01		tukan	tukan	eng:fra:toucan, deu:Tukan, spa:tucán, por:tucano, rus:тукан (tukan), fas: توکان (tukân), ara: طُوقَان (ṭūqān),tam:தூக்கான் (tūkkāṉ), may:tur:tukan, zho:鵎鵼 (tuǒkōng), vie:tucăng
+PWN:touch.v.01		takte	takt'e	eng:tactile, fra:tact, por:tato, spa:tacto
 PWN:touch.v.05		kontakte	kon.takt'e	
-PWN:touch.v.05		takte	takt'e	eng:tactile, fra:tact, por:tato, spa:tacto
 PWN:towel.n.01		tual	tual	eng:towel, fra:touaille, spa:toalla, por:toalha, jpn:タオル (taoru), kor:타월 (tawol), hin:तौलिया (tauliyā), ben:তোয়ালে (toẏale), tam:துவாலை (tuvālai), may:tuala + deu:Toilette, rus:туалет (tualet), ara: تْوَالِيتّ‎ (twālitt), fas: توالت‎ (tuâlet), vie:toa-lét, tur:tuvalet
 PWN:town.n.01		pol	pol	eng:spa:-polis, deu:fra:por:-pole, rus:-поль (-pol'), may:tur:-pol
 PWN:toxin.n.01		biotoxe	bio·tox'e	
@@ -1742,7 +1743,7 @@ PWN:trick.n.01		truk	truk	eng:trick, deu:Trick, fra:truc, spa:truco, por:truque,
 PWN:true.a.01		ver	ver	
 PWN:trust.v.01		amen	amen	
 PWN:truth.n.01		hakita	hak·ita	
-PWN:try.v.01		teste	test'e	eng:test, por:teste, spa:test, rus:тест (test), tur:test, fas:تست (test), jpn:テスト (tesuto)
+PWN:try.v.01		koshi	koshi	fas: کوشیدن (kušidan), hin:कोशिश (kośiś) + zho:试 (shì), yue:試 (si3), jpn:試 (shi), kor:시 (si)
 PWN:tube.n.01		tube	tub'e	spa:por:tubo, eng:fra:tube, jpn:チューブ (chūbu), zul:ithumbu, xho:íthumbu
 PWN:tundra.n.01		tundra	tundra	eng:spa:por:tur:tundra, rus:тундра (tundra), ara:تندرا‎ (tundrā), hin:टुंड्रा (ṭuṇḍrā), jpn:ツンドラ (tsundora)
 PWN:tungsten.n.01		volfram	volfram	eng:wolfram, spa:wolframio, rus:вольфрам, zho:钨 (wū), vie:vonfam, may:wolfram, swa:wolframi
@@ -1764,7 +1765,7 @@ PWN:ununpentium.n.01		moskovium	moskov·ium	eng:fra:moscovium, spa:moscovio, por
 PWN:ununquadium.n.01		flerovium	flerov·ium	eng:may:flerovium, fra:flérovium, spa:flerovio, por:fleróvio, rus:флеровий, zho: (fū), jpn:フレロビウム, kor:플레로븀, vie:flerovi, swa:flerovi
 PWN:ununtrium.n.01		niponium	nipon·ium	eng:fra:may:nihonium, spa:nihonio, por:nihonium, rus:нихоний, jpn:ニホニウム, kor:우눈트륨, vie:swa:nihoni
 PWN:unwind.v.01		devolu	de.volu	
-PWN:update.v.02		nov	nov	
+PWN:update.v.02		novifa	nov·ifa	
 PWN:uranium.n.01		uranium	uran·ium	eng:uranium, fra:uranium, spa:uranio, por:urânio, rus:уран, jpn:ウラン, kor:우라늄, vie:urani (uran), hin:युरेनियम, ben:ইউরেনিয়াম, may:uranium, swa:urani, ara: يورانيوم
 PWN:urban.a.01		polik	pol·ik	
 PWN:urine.n.01		pisha	pisha	eng:piss, deu:Pisse, fra:pisse, fas:پیشاب (pišâb), hin:पेशाब (pešāb), ben:পেশাব (peśab), may:pipis


### PR DESCRIPTION
This commit creates the following new Pandunia words: _anou_ ('acknowledge'), _disparte_ ('disperse'), _rota_ ('rotate'), _tu_ ('too'), _chuz_ ('choose'), _bok_ ('thin'), _korte_ ('short'), _teste_ ('try'), _takte_ ('touch'), _kontakte_ ('contact'), _kargo_ ('charge' or 'cargo'), _pagina_ ('page'), _eureka_ ('find'), and _veieureka_ ('navigate').

I also added new meanings to some existing words: 'tear' for _frag_, 'save' for _hazin_, 'hide' for _sir_, and 'update' for _nov_.

Finally, I added the following words that were in the Pandunia wobsite but not in the dictionary: _viz_ ('see'), _previz_ ('preview' or 'foresee'), _dit_ ('say'), _predit_ ('predict'), and _vei_ ('way').