### PR TITLE
new Pandunia words: kenar, dekargo, busola, and more

### DIFF
--- a/concepts/E/eng-definition.tsv
+++ b/concepts/E/eng-definition.tsv
@@ -521,6 +521,7 @@ PWN:antic.n.01	a ludicrous or grotesque act done for fun and amusement
 PWN:anticipate.v.03	realize beforehand
 PWN:anticipation.n.01	an expectation
 PWN:antimony.n.01	Antimony, the chemical element with atomic number 51 and symbol Sb.
+PWN:antique.s.02	out of fashion
 PWN:antithesis.n.01	a proposition that is the exact opposite of some other proposition
 PWN:antithetic.s.01	sharply contrasted in character or purpose
 PWN:antonym.n.01	a word that expresses a meaning opposed to the meaning of another word, in which case the two words are antonyms of each other
@@ -1696,6 +1697,8 @@ PWN:compare.v.02	be comparable
 PWN:compare.v.03	consider or describe as similar, equal, or analogous
 PWN:comparison.n.01	the act of examining resemblances
 PWN:comparison.n.02	relation based on similarities and differences
+PWN:compass.n.01	navigational instrument for finding directions
+PWN:compass.n.04	drafting instrument for drawing circles
 PWN:compass_point.n.01	any of 32 horizontal directions indicated on the card of a compass
 PWN:compassion.n.01	a deep awareness of and sympathy for another's suffering
 PWN:compel.v.01	force somebody to do something
@@ -2405,6 +2408,7 @@ PWN:doubt.v.02	Be unsure about the truth or accuracy of a matter.
 PWN:dough.n.01	A mixture of flour and water ready to be baked into bread, pastry etc.
 PWN:dove.n.01	One of several birds of the family Columbidae.
 PWN:down.r.01	Moving to a lower position.
+PWN:download.v.01	transfer a file or program from a central computer to a smaller computer or to a computer at a remote location
 PWN:drag.v.01	To draw slowly or heavily.
 PWN:drag_up.v.01	mention something unpleasant from the past
 PWN:dragon.n.01	A mythical creature typically depicted as a winged, fire-breathing reptile with magical qualities.
@@ -2633,6 +2637,7 @@ PWN:engender.v.01	call forth
 PWN:engine.n.01	motor that converts thermal energy to mechanical work
 PWN:engineer.n.01	a person who uses scientific knowledge to solve practical problems
 PWN:engineering.n.02	the discipline dealing with the art or science of applying scientific knowledge to practical problems
+PWN:english.a.01	of or relating to or characteristic of England or its culture or people
 PWN:enjoy.v.02	have benefit from
 PWN:enjoy.v.04	have for one's benefit
 PWN:enlistment.n.01	a period of time spent in military service
@@ -3366,6 +3371,7 @@ PWN:greet.v.01	To welcome someone; to address someone in a friendly and welcomin
 PWN:greet.v.02	send greetings to
 PWN:greeting.n.01	(usually plural) an acknowledgment or expression of good will (especially on meeting)
 PWN:grey.s.01	Having a colour between black and white, like ash or stone.
+PWN:grid.n.01	a pattern of regularly spaced horizontal and vertical lines
 PWN:griddle.n.01	A metal or stone flat plate on which food is fried or baked.
 PWN:grief.n.01	intense sorrow caused by loss of a loved one (especially by death)
 PWN:grief.n.02	Mental suffering or pain caused by injury, loss, or despair.
@@ -4073,6 +4079,7 @@ PWN:lasso.n.02	A long rope with a sliding loop on one end, generally used in ran
 PWN:last.a.02	The last, after all the others.
 PWN:last.v.01	To endure, continue over time.
 PWN:late.r.01	Towards the end of a time period.
+PWN:latin.a.01	of or relating to the ancient Latins or the Latin language
 PWN:laud.v.01	praise, glorify, or honor
 PWN:laugh.n.01	the sound of laughing
 PWN:laugh.v.01	To express pleasure, mirth or derision by peculiar movement of the muscles of the face, particularly of the mouth, causing a lighting up of the face and eyes, and usually accompanied by the emission of explosive or chuckling sounds from the chest and throat.
@@ -5016,6 +5023,7 @@ PWN:organization.n.06	the activity or result of distributing or disposing person
 PWN:organize.v.02	cause to be structured or ordered or operating according to some principle or idea
 PWN:organized_crime.n.01	underworld organizations
 PWN:orientation.n.02	an integrated set of attitudes and beliefs
+PWN:orientation.n.03	position or alignment relative to points of the compass or other specific directions
 PWN:orifice.n.01	an aperture or hole that opens into a bodily cavity
 PWN:origin.n.03	an event that is a beginning; a first part or stage of subsequent events
 PWN:origin.n.04	the point of intersection of coordinate axes; where the values of the coordinates are all zero
@@ -5948,6 +5956,7 @@ PWN:rhenium.n.01	Rhenium, the chemical element with atomic number 75 and symbol 
 PWN:rhetorical_device.n.01	a use of language that creates a literary effect (but often without regard for literal significance)
 PWN:rhinal.a.01	of or in or relating to the nose
 PWN:rhodium.n.01	Rhodium, the chemical element with atomic number 45 and symbol Rh.
+PWN:rhumb_line.n.01	a line on a sphere that cuts all meridians at the same angle; the path taken by a ship or plane that maintains a constant compass direction
 PWN:rhythm.n.01	the basic rhythmic unit in a piece of music
 PWN:rib.n.02	One of the long curved bones which form the rib cage.
 PWN:rib.n.05	a riblike supporting or strengthening part of an animal or plant
@@ -6067,6 +6076,7 @@ PWN:rush.v.01	To move quickly (of a vehicle).
 PWN:rush.v.04	Move in great haste.
 PWN:rush.v.04	To move or do something at a fast pace.
 PWN:rush.v.05	run with the ball, in football
+PWN:russian.a.01	of or pertaining to or characteristic of Russia or its people or culture or language
 PWN:rust.n.01	a red or brown oxide coating on iron or steel caused by the action of oxygen and moisture
 PWN:rustle.v.01	A sound emitted by leaves moving in the trees.
 PWN:ruthenium.n.01	Ruthenium, the chemical element with atomic number 44 and symbol Ru.
@@ -6234,6 +6244,7 @@ PWN:separate.v.08	discontinue an association or relation; go different ways
 PWN:separate.v.09	go one's own way; move apart
 PWN:separate.v.12	come apart
 PWN:separation.n.09	the act of dividing or disconnecting
+PWN:sepia.n.02	rich brown pigment prepared from the ink of cuttlefishes
 PWN:september.n.01	The 9th month of the Gregorian calendar.
 PWN:sequence.n.01	sequence, order (temporal arrangement of events in a series)
 PWN:series.n.01	similar things placed in order or happening one after another
@@ -6554,6 +6565,7 @@ PWN:space.n.07	a blank area
 PWN:spacing.n.02	the property possessed by an array of things that have space between them
 PWN:spade.n.02	Tool having a flat and sharp metal tip and a wooden handle used to break, dig and move the earth.
 PWN:spain.n.01	a parliamentary monarchy in southwestern Europe on the Iberian Peninsula; a former colonial power
+PWN:spanish.a.01	of or relating to or characteristic of Spain or the people of Spain
 PWN:spare.v.03	give up what is not strictly needed
 PWN:spark.n.06	A small particle or body of shining or glowing matter, either molten or on fire.
 PWN:spatial_property.n.01	any property relating to or occupying space
@@ -7008,6 +7020,7 @@ PWN:testify.v.02	provide evidence for
 PWN:testis.n.01	The male sex gland that produces sperm and male hormones, found in some types of animals and humans.
 PWN:tether.v.01	To attach an animal to something to prevent that it leaves.
 PWN:text.n.01	the words of something written
+PWN:texture.n.01	the feel of a surface or a fabric
 PWN:thallium.n.01	Thallium, the chemical element with atomic number 81 and symbol Tl.
 PWN:thank.v.01	express gratitude or show appreciation to
 PWN:thanks.n.01	an acknowledgment of appreciation
@@ -7345,6 +7358,7 @@ PWN:unwind.v.01	reverse the winding or twisting of
 PWN:unwrap.v.02	make known to the public information that was previously known only to a few people or that was meant to be kept a secret
 PWN:up.r.01	Moving to a higher position.
 PWN:update.v.02	bring up to date; supply with recent information
+PWN:upload.v.01	transfer a file or program to a central computer from a smaller computer or from a computer at a remote location
 PWN:upper_bound.n.01	(mathematics) a number equal to or greater than any other number in a given set
 PWN:upset.v.02	cause to lose one's composure
 PWN:uranium.n.01	Uranium, the chemical element with atomic number 92 and symbol U.
@@ -7519,6 +7533,7 @@ PWN:weather.n.01	The day-to-day meteorological conditions, especially temperatur
 PWN:weave.v.01	To weave a basket or use similar techniques for creating other objects.
 PWN:weave.v.02	To create a fabric by interlacing threads.
 PWN:weave.v.04	to move or cause to move in a sinuous, spiral, or circular course
+PWN:web.n.01	an intricate network suggesting something that was formed by weaving or interweaving
 PWN:wedding.n.01	the social event at which the ceremony of marriage is performed
 PWN:wedge.n.01	any shape that is triangular in cross section
 PWN:wednesday.n.01	The third day of the week in Europe and in systems using the ISO 8601 norm; the fourth day of the week in the United States of America.

--- a/data/id_map.tsv
+++ b/data/id_map.tsv
@@ -516,6 +516,7 @@ PWN:antic.n.01	00427580-n
 PWN:anticipate.v.03	00720808-v				
 PWN:anticipation.n.01	07511080-n				
 PWN:antimony.n.01	14628668-n				
+PWN:antique.s.02	00974159-a				
 PWN:antithesis.n.01	13855230-n				
 PWN:antithetic.s.01	02065404-a				
 PWN:antonym.n.01	06288024-n				
@@ -1691,6 +1692,8 @@ PWN:compare.v.02	02729632-v
 PWN:compare.v.03	00653620-v				
 PWN:comparison.n.01	00142665-n				
 PWN:comparison.n.02	13853808-n				
+PWN:compass.n.01	03080497-n				
+PWN:compass.n.04	03080633-n				
 PWN:compass_point.n.01	13830305-n				
 PWN:compassion.n.01	07553741-n				
 PWN:compel.v.01	02506546-v				
@@ -2400,6 +2403,7 @@ PWN:doubt.v.02	00687523-v	3536	17-99907		1926
 PWN:dough.n.01	07860988-n	273	5-53		
 PWN:dove.n.01	01812337-n	1853	3-594		
 PWN:down.r.01	00095320-r	1326	12-03	hinab::ADV	2902
+PWN:download.v.01	02233704-v				
 PWN:drag.v.01	01453433-v	2030		schleppen::V	
 PWN:drag_up.v.01	01025785-v				
 PWN:dragon.n.01	09494388-n	2038			937
@@ -2628,6 +2632,7 @@ PWN:engender.v.01	01649024-v
 PWN:engine.n.01	03287733-n				
 PWN:engineer.n.01	09615807-n				
 PWN:engineering.n.02	06125041-n				
+PWN:english.a.01	03003344-a				
 PWN:enjoy.v.02	01192510-v				
 PWN:enjoy.v.04	02110793-v				
 PWN:enlistment.n.01	15293590-n				
@@ -3363,6 +3368,7 @@ PWN:greet.v.01	00897241-v	3552	18-99909
 PWN:greet.v.02	00897125-v				
 PWN:greeting.n.01	06630017-n				
 PWN:grey.s.01	00389310-s	153	15-99902	grau::A	832
+PWN:grid.n.01	05931512-n				
 PWN:griddle.n.01	03459328-n		7-99903		
 PWN:grief.n.01	07535010-n				
 PWN:grief.n.02	05833683-n	1668	16-32	Kummer::N	
@@ -4071,6 +4077,7 @@ PWN:lasso.n.02	03644378-n	340	8-29
 PWN:last.a.02	01013279-a	1529	13-35	letzter::A	3261
 PWN:last.v.01	02704928-v	1186	14-252		
 PWN:late.r.01	00100267-r	477	14-17		3252
+PWN:latin.a.01	03080101-a				
 PWN:laud.v.01	00860620-v				
 PWN:laugh.n.01	07127006-n				
 PWN:laugh.v.01	00031820-v	1355	16-25	lachen::V	743
@@ -5016,6 +5023,7 @@ PWN:organization.n.06	01008378-n
 PWN:organize.v.02	02432530-v				1676
 PWN:organized_crime.n.01	08245172-n				
 PWN:orientation.n.02	06208021-n				
+PWN:orientation.n.03	13828075-n				
 PWN:orifice.n.01	05249636-n				
 PWN:origin.n.03	07323922-n				
 PWN:origin.n.04	06009086-n				
@@ -5948,6 +5956,7 @@ PWN:rhenium.n.01	14652390-n
 PWN:rhetorical_device.n.01	07098193-n				
 PWN:rhinal.a.01	02978781-a				
 PWN:rhodium.n.01	14652623-n				
+PWN:rhumb_line.n.01	08632678-n				
 PWN:rhythm.n.01	07086518-n				3222
 PWN:rib.n.02	05279026-n	801	4-162		
 PWN:rib.n.05	05235879-n				
@@ -6067,6 +6076,7 @@ PWN:rush.v.01	02058994-v	2863		sausen::V
 PWN:rush.v.04	00459498-v	2860		eilen::V	3254
 PWN:rush.v.04	00459498-v	754	14-23	sich beeilen::V	
 PWN:rush.v.05	02059770-v				
+PWN:russian.a.01	02957276-a				
 PWN:rust.n.01	14889479-n	3064	9-99916		3549
 PWN:rustle.v.01	02182662-v	2877		rauschen::V	
 PWN:ruthenium.n.01	14653242-n				
@@ -6234,6 +6244,7 @@ PWN:separate.v.08	02431320-v
 PWN:separate.v.09	02030158-v				
 PWN:separate.v.12	01557774-v				
 PWN:separation.n.09	00383606-n				
+PWN:sepia.n.02	15021927-n				
 PWN:september.n.01	15212739-n	2852		September::N	4009
 PWN:sequence.n.01	08459252-n				3260
 PWN:series.n.01	08457976-n				3259
@@ -6554,6 +6565,7 @@ PWN:space.n.07	06389553-n
 PWN:spacing.n.02	05083328-n				
 PWN:spade.n.02	04266486-n	1176	8-23	Spaten::N	
 PWN:spain.n.01	09023321-n		19-99911		
+PWN:spanish.a.01	02958576-a				
 PWN:spare.v.03	02345647-v				
 PWN:spark.n.06	09442341-n	518		Funke::N	
 PWN:spatial_property.n.01	05062748-n				
@@ -7008,6 +7020,7 @@ PWN:testify.v.02	01015244-v
 PWN:testis.n.01	05524615-n	797	4-49		556
 PWN:tether.v.01	01290009-v	2891		anbinden::V	
 PWN:text.n.01	06387980-n				
+PWN:texture.n.01	04946877-n				
 PWN:thallium.n.01	14657818-n				
 PWN:thank.v.01	00892315-v	2412	18-99911		2227
 PWN:thanks.n.01	07228971-n				
@@ -7345,6 +7358,7 @@ PWN:unwind.v.01	01523654-v
 PWN:unwrap.v.02	00933821-v				
 PWN:up.r.01	00096333-r	1591	12-08	hinauf::ADV	2901
 PWN:update.v.02	00833546-v				
+PWN:upload.v.01	02233898-v				
 PWN:upper_bound.n.01	13903855-n				
 PWN:upset.v.02	01790020-v				
 PWN:uranium.n.01	14660443-n				
@@ -7519,6 +7533,7 @@ PWN:weather.n.01	11524662-n	952	1-78	Wetter::N	1120
 PWN:weave.v.01	01518924-v	3296	9-99902		
 PWN:weave.v.02	01673891-v	133	6-33		1421
 PWN:weave.v.04	01882814-v				
+PWN:web.n.01	09477037-n				
 PWN:wedding.n.01	07452074-n				
 PWN:wedge.n.01	13919547-n				3527
 PWN:wednesday.n.01	15164233-n	1694	14-65	Mittwoch::N	4023

--- a/dict/E/eng.tsv
+++ b/dict/E/eng.tsv
@@ -1003,6 +1003,9 @@ PWN:anticipate.v.03		foresee
 PWN:anticipation.n.01		anticipation		
 PWN:anticipation.n.01		expectancy		
 PWN:antimony.n.01		antimony		
+PWN:antique.s.02		antiquated		
+PWN:antique.s.02		antique		
+PWN:antique.s.02		old-fashioned		
 PWN:antithesis.n.01		antithesis		
 PWN:antithetic.s.01		antithetic		
 PWN:antithetic.s.01		antithetical		
@@ -4055,6 +4058,9 @@ PWN:compare.v.03		liken
 PWN:comparison.n.01		comparing		
 PWN:comparison.n.01		comparison		
 PWN:comparison.n.02		comparison		
+PWN:compass.n.01		compass		
+PWN:compass.n.04		compass		
+PWN:compass.n.04		pair of compasses		
 PWN:compass_point.n.01		compass point		
 PWN:compass_point.n.01		point		
 PWN:compassion.n.01		compassion		
@@ -5870,6 +5876,7 @@ PWN:down.r.01		down		:*dounon
 PWN:down.r.01		downward		
 PWN:down.r.01		downwardly		
 PWN:down.r.01		downwards		
+PWN:download.v.01		download		
 PWN:drag.v.01		drag		
 PWN:drag.v.01		haul		
 PWN:drag.v.01		tow		
@@ -6429,6 +6436,7 @@ PWN:engineering.n.02		applied science
 PWN:engineering.n.02		engineering		
 PWN:engineering.n.02		engineering science		
 PWN:engineering.n.02		technology		
+PWN:english.a.01		English		
 PWN:enjoy.v.02		enjoy		
 PWN:enjoy.v.04		enjoy		
 PWN:enlistment.n.01		duty tour		
@@ -8222,6 +8230,9 @@ PWN:grey.s.01		gray
 PWN:grey.s.01		grayish		
 PWN:grey.s.01		grey		
 PWN:grey.s.01		greyish		
+PWN:grid.n.01		array		
+PWN:grid.n.01		grid		
+PWN:grid.n.01		lattice		
 PWN:griddle.n.01		griddle		
 PWN:grief.n.01		brokenheartedness		
 PWN:grief.n.01		grief		
@@ -9844,6 +9855,7 @@ PWN:last.v.01		take time
 PWN:late.r.01		belatedly		
 PWN:late.r.01		late		
 PWN:late.r.01		tardily		
+PWN:latin.a.01		Latin		
 PWN:laud.v.01		commend	
 PWN:laud.v.01		exalt		
 PWN:laud.v.01		extol		
@@ -11964,6 +11976,8 @@ PWN:organized_crime.n.01		gangdom
 PWN:organized_crime.n.01		gangland		
 PWN:organized_crime.n.01		organized crime		
 PWN:orientation.n.02		orientation		
+PWN:orientation.n.03		bearing		
+PWN:orientation.n.03		orientation		
 PWN:orifice.n.01		opening		
 PWN:orifice.n.01		orifice		
 PWN:orifice.n.01		porta		
@@ -14243,6 +14257,8 @@ PWN:rhetorical_device.n.01		rhetorical device
 PWN:rhinal.a.01		nasal		
 PWN:rhinal.a.01		rhinal		
 PWN:rhodium.n.01		rhodium		
+PWN:rhumb_line.n.01		loxodrome		
+PWN:rhumb_line.n.01		rhumb line		
 PWN:rhythm.n.01		beat		
 PWN:rhythm.n.01		musical rhythm		
 PWN:rhythm.n.01		rhythm		
@@ -14529,6 +14545,7 @@ PWN:rush.v.04		hurry
 PWN:rush.v.04		look sharp		
 PWN:rush.v.04		rush		
 PWN:rush.v.05		rush		
+PWN:russian.a.01		Russian		
 PWN:rust.n.01		rust		
 PWN:rustle.v.01		rustle		
 PWN:ruthenium.n.01		ruthenium		
@@ -14884,6 +14901,7 @@ PWN:separate.v.12		divide
 PWN:separate.v.12		part		
 PWN:separate.v.12		separate		
 PWN:separation.n.09		separation		
+PWN:sepia.n.02		sepia		
 PWN:september.n.01		Sep		
 PWN:september.n.01		Sept		
 PWN:september.n.01		September		
@@ -15599,6 +15617,7 @@ PWN:spacing.n.02		spatial arrangement
 PWN:spade.n.02		spade		
 PWN:spain.n.01		Espana		
 PWN:spain.n.01		Spain		
+PWN:spanish.a.01		Spanish		
 PWN:spare.v.03		dispense with		
 PWN:spare.v.03		give up		
 PWN:spare.v.03		part with		
@@ -16650,6 +16669,7 @@ PWN:testis.n.01		testis
 PWN:tether.v.01		tether		
 PWN:text.n.01		text		
 PWN:text.n.01		textual matter		
+PWN:texture.n.01		texture		
 PWN:thallium.n.01		thallium		
 PWN:thank.v.01		give thanks		
 PWN:thank.v.01		thank		
@@ -17420,6 +17440,7 @@ PWN:up.r.01		upwardly
 PWN:up.r.01		upwards		
 PWN:update.v.02		renew		
 PWN:update.v.02		update		
+PWN:upload.v.01		upload		
 PWN:upper_bound.n.01		upper bound		
 PWN:upset.v.02		discomfit		
 PWN:upset.v.02		discompose		
@@ -17838,6 +17859,7 @@ PWN:weave.v.04		thread
 PWN:weave.v.04		wander		
 PWN:weave.v.04		weave		
 PWN:weave.v.04		wind		
+PWN:web.n.01		web		
 PWN:web_log.n.01		blog		
 PWN:web_log.n.01		web log		
 PWN:wedding.n.01		hymeneals		

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -457,8 +457,8 @@ PWN:committee.n.01		komisia	ko.mis·ia
 PWN:common.a.01		konhave	kon·hav'e	
 PWN:companion.n.01		sahib	sahib	ara: صَاحِب (ṣāḥib), fas: صاحب (sāhib), hin:साहिब (sāhib), ben:সাহেব (śaheb), may:sahabat, swa:sahibu
 PWN:compare.v.03		kompar	kom.par	
-PWN:compass.n.01		busola	busola	fra:boussole, spa:brújula, por:bússola, ara:بُوصُلَة (būṣula), tur:pusula, rus:буссо́ль (bussól’)
-PWN:compass.n.04		pergar	pergar	fas:پَرْگار (pargâr), tur:pergel, ara:بِرْكَار (birkār), swa:bikari
+PWN:compass.n.01		gik dikator	gik dika·tor	
+PWN:compass.n.04		sirke grafor	sirke grafor	
 PWN:compassion.n.01		kompatia	kom.pat·ia	
 PWN:complex.a.01		komple	kom.pl’e	
 PWN:computer.n.01		komputer	kom.put·er	
@@ -1010,7 +1010,8 @@ PWN:large.a.01		dai	dai	yue:大 (daai), zho:大 (dá), vie:đại, jpn:(dai,tai)
 PWN:larva.n.01		larva	larva	deu:fra:larve, eng:tur:larva, hin:लार्वा (lārvā), urd:(lārvā), pol:larwa
 PWN:last.a.02		final	fin·al	
 PWN:last.v.01		dura	dura	
-PWN:latin.a.01		rus	rus	
+PWN:latin.a.01		latine	latine	
+PWN:russian.a.01		rus	rus	
 PWN:laud.v.01		halelu	halelu	heb:(hal'lu yah), eng:hallelujah, zho:哈利路亚 (hālìlùyà), ara:(hallilūyā), por:fra:alléluia, rus:аллилуйя (alliluyya), spa:aleluya, swa:may:haleluya, tgl:aleluya, jpn:ハレルヤ (hareruya), kor:할렐루야 (hallelluya)
 PWN:laugh.v.01		haha	haha	
 PWN:laughter.n.02		haha	haha	

--- a/dict/P/pandunia.tsv
+++ b/dict/P/pandunia.tsv
@@ -166,6 +166,7 @@ PWN:antibiotic.a.01		antibiotik	anti·bio·tik
 PWN:antichrist.n.01		antikriste	anti.krist'e	
 PWN:anticipate.v.03		previz	pre.viz	
 PWN:antimony.n.01		stibium	stib·ium	zho:锑 (tī), swa:stibi
+PWN:antique.s.02		laostil	lao·stil	
 PWN:antithesis.n.01		antites	anti.tes	
 PWN:antithetic.s.01		antitesik	anti.tes·ik	
 PWN:antonym.n.01		antinim	anti.nim	
@@ -321,6 +322,7 @@ PWN:boot.n.01		botin	bot·in
 PWN:boron.n.01		boron	boron	eng:boron, fra:boron, spa:boro, por:boro, rus:бор, vie:bo, hin:बोरॉन्, ben:বোরন, may:boron, swa:boroni, ara: بورون
 PWN:both.s.01		hol du	hol du	
 PWN:bottle.n.01		botel	botel	eng:bottle, fra:bouteille, spa:botella, por:botelha, rus:бутылка (butylka), fas: بطری‎ (botri), hin:बोतल (botal), ben:বোতল (botôl), may:botol, tam:புட்டி (puṭṭi), ful:butél
+PWN:boundary_line.n.01		kenar	kenar	fas:کِنار (kenâr), hin:किनारा (kinārā), ben:কিনার (kinar), pan:ਕਨਾਰਾ (kinārā), tur:kenar, ara:كَنَار (kanār)
 PWN:bow.n.04		gung	gung	zho:弓 (gōng), yue:弓 (gung1), jpn:弓 (kyū), kor:궁 (gung), vie:cung
 PWN:bow.v.01		namas	namas	san:नमस् (namas), hin:नमस्कार (namaskār), ben:নমস্কার (nomoskar), zho:南无 (nāmó), yue:南無 (naa1mou4), jpn:南無 (namu), fas:نماز (namâz), tur:namaz
 PWN:bowl.n.01		tasa	tasa	ara: طَاس (ṭās), hau:tasa, swa:tasa, ful:taasa, tur:tas, deu:Tasse, fra:tasse, spa:taza, rus:таз (taz), hin:तश्तरी (tashtarī)
@@ -455,6 +457,8 @@ PWN:committee.n.01		komisia	ko.mis·ia
 PWN:common.a.01		konhave	kon·hav'e	
 PWN:companion.n.01		sahib	sahib	ara: صَاحِب (ṣāḥib), fas: صاحب (sāhib), hin:साहिब (sāhib), ben:সাহেব (śaheb), may:sahabat, swa:sahibu
 PWN:compare.v.03		kompar	kom.par	
+PWN:compass.n.01		busola	busola	fra:boussole, spa:brújula, por:bússola, ara:بُوصُلَة (būṣula), tur:pusula, rus:буссо́ль (bussól’)
+PWN:compass.n.04		pergar	pergar	fas:پَرْگار (pargâr), tur:pergel, ara:بِرْكَار (birkār), swa:bikari
 PWN:compassion.n.01		kompatia	kom.pat·ia	
 PWN:complex.a.01		komple	kom.pl’e	
 PWN:computer.n.01		komputer	kom.put·er	
@@ -591,6 +595,7 @@ PWN:dominoes.n.01		domino	domino	eng:dominoes, spa:por:dominó, fra:dominos, rus
 PWN:double.s.03		duple	du·pl'e	
 PWN:doubt.n.01		shak	shak	ara: شَكَّ‎ (šakka), fas: شک‎ (šak), hin:शक (śak); शंका (śankā), may:syak; sangka, tur:şek, swa:shaka; -shuku, hau:shakka
 PWN:doubt.v.02		shak	shak	
+PWN:download.v.01		dekargo	de.kargo	
 PWN:drag.v.01		trakte	trakt'e	spa:traer + eng:tractor, fra:tracteur, por:trator, rus:трактор (traktor), ara: تَرَاكْتُور‎ (tarāktūr), zho:拖拉機 (tuōlājī), jpn:トラクター (torakutā), kor:트랙타 (teuraekta), hin:ट्रैक्टर (ṭraikṭar), ben:ট্র্যাক্টর (ṭrækṭôr), may:traktor, swa:trekta, tur:traktör
 PWN:dragon.n.01		drak	drak	eng:fra:dragon, spa:dragón, por:dragão, deu:Drache, rus:дракон (drakon), jpn:ドラゴン (doragon), kor:드래곤 (deuraegon), swa:dragoni
 PWN:dramatic.a.01		dramatik	drama·tik	
@@ -649,6 +654,7 @@ PWN:end_product.n.01		chutet	chut·et
 PWN:enemy.n.01		inamik	in.am·ik	
 PWN:energy.n.01		energia	energ·ia	eng:energy, spa:energía, por:energia, fra:énergie, rus:энергия (energiya), tur:enerji, fas:انرژی‎ (enerži), jpn:エネルギー (enerugī)
 PWN:engineer.n.01		enjener	enjen·er	eng:engineer, spa:ingeniero, por:engenheiro, rus:инженер (inzhener), hin:mar:इंजीनियर (iñjīniyar), jpn:エンジニア (enjinia), may:insinyur
+PWN:english.a.01		english	english	
 PWN:enough.r.01		bas	bas	spa:por:ita:basta + ara:fas:urd:س (bas), hin:(bas), swa:basi
 PWN:enter.v.01		entra	en.tra	
 PWN:entertainment_industry.n.01		shou biz	shou biz	
@@ -744,6 +750,7 @@ PWN:flower.n.02		hua	hua	zho:花 (huā), yue:花 (faa1), vie:hoa, kor:화 (hwa) 
 PWN:fluid.s.02		darik	dar·ik	
 PWN:fluorine.n.01		flur	flur	eng:fluorine, fra:fluor, spa:flúor, por:flúor, rus:фтор, zho:氟 (fú), jpn:フッ素, kor:플루오르, vie:flo, hin:फ्लोरीन, ben:ফ্লুরিন, may:fluor, swa:florini, ara: فلور
 PWN:foam.n.01		pena	pena	rus:пена (pena), hin:फेन (phena), ben:ফেনা (phena), tam:பேனம் (pēṉam)
+PWN:focus.n.01		fokus	fokus	eng:fra:focus, por:spa:foco, deu:Fokus, rus:фо́кус (fókus)
 PWN:folk.n.01		pop	pop	eng:people, fra:peuple, spa:pueblo, por:povo + deu:populär, rus:популярный (populyarnïy), may:populer, tur:popüler, zho:波普 (bōpǔ) + jpn:ポピュリズム (popyurizumu), kor:포퓰리즘 (popyullijeum)
 PWN:following.s.02		posik	pos·ik	
 PWN:foot.n.01		fut	fut	eng:foot, deu:Pfote
@@ -822,6 +829,7 @@ PWN:green.s.01		grin	grin	eng:green, deu:grün
 PWN:greens.n.01		cai	cai	zho:菜 (cài), yue:菜 (coi3), eng:-choy, may:-coy
 PWN:greet.v.01		salam	sal.am	
 PWN:grey.s.01		gris	gris	eng:grey, deu:grau, fra:spa:gris, tur:gri
+PWN:grid.n.01		retogonia	ret·o·gon·ia	
 PWN:grind.v.05		mol	mol	zho:磨 (mò), yue:磨 (mo4) tha:โม่ (mo), fra:moulin, spa:molino, rus:молоть  (molot’)
 PWN:grok.v.01		komprende	kom.prend'e	
 PWN:group.n.01		grup	grup	deu:Gruppe, fra:groupe, eng:group, spa:por:grupo, rus:группа (gruppa), kor:그룹 (geurup), jpn:グループ (gurūpu), tur:grup, hin:ग्रूप (grūp)
@@ -1002,6 +1010,7 @@ PWN:large.a.01		dai	dai	yue:大 (daai), zho:大 (dá), vie:đại, jpn:(dai,tai)
 PWN:larva.n.01		larva	larva	deu:fra:larve, eng:tur:larva, hin:लार्वा (lārvā), urd:(lārvā), pol:larwa
 PWN:last.a.02		final	fin·al	
 PWN:last.v.01		dura	dura	
+PWN:latin.a.01		rus	rus	
 PWN:laud.v.01		halelu	halelu	heb:(hal'lu yah), eng:hallelujah, zho:哈利路亚 (hālìlùyà), ara:(hallilūyā), por:fra:alléluia, rus:аллилуйя (alliluyya), spa:aleluya, swa:may:haleluya, tgl:aleluya, jpn:ハレルヤ (hareruya), kor:할렐루야 (hallelluya)
 PWN:laugh.v.01		haha	haha	
 PWN:laughter.n.02		haha	haha	
@@ -1121,6 +1130,7 @@ PWN:mercenary.n.01		soldat	solda·t	eng:soldier, deu:Soldat, fra:soldat, spa:por
 PWN:mercury.n.01		hidrargente	hidrargente	swa:hidrajiri
 PWN:message.n.01		anjil	anjil	ell:ἀγγελία (angelía), ara: إنجيل (ʾinjīl), swa:injili, may:injil, tur:incil, fas: انجیل (enjil), hin:इंजील (iñjīl), ben:ইঞ্জীল (injīl), tam:இஞ்சீல் (iñcīl), eng:evangel, fra:évangile, por:evangelho, rus:евангелие (evangeliye)
 PWN:message.n.01		misaje	mis·aj'e	
+PWN:message.n.02		kontenet	kon.ten·et	
 PWN:metallic_element.n.01		metal	metal	eng:spa:por:tur:metal, fra:métal, deu:Metall, rus:металл (metall), tur:metal
 PWN:meter.n.01		mitre	mitr'e	eng:tur:metre, deu:may:meter, fra:mètre, spa:por:metro, rus:метр (metr), ara: متر‎ (mitr), zho:米 (mǐ), jpn:メートル (mētoru), kor:미터 (miteo), vie:mét, hin:मीटर (mīṭar), ben:মিটার (miṭar), swa:hau:mita, ful:meter
 PWN:meter.n.02		metrer	metr·er	
@@ -1147,6 +1157,7 @@ PWN:minute.n.01		minut	minut	eng:minute, spa:por:minuto, rus:мину́та (min
 PWN:miracle.n.01		mirakul	mira·kul	
 PWN:mirror.n.01		mirer	mir·er	
 PWN:misfortune.n.02		bela	bela	ara: بَلَاء (balāʾ), fas: بلا (balâ), hin:बला (balâ), may:bala, tur:bela, orm:swa:balaa, hau:bala'i + rus:боль (bol'); беда (beda)
+PWN:modern.a.01		novostil	nov·o·stil	
 PWN:mole.n.06		krot	krot	
 PWN:molybdenum.n.01		moliden	moliden	eng:molybdenum, fra:molybdène, spa:molibdeno, por:molibdénio, rus:молибден, zho:钼 (mù), jpn:モリブデン, kor:몰리브덴, vie:molypđen, hin:मोलिब्डेनम, ben:মলিবডেনাম, may:molibden, swa:molibdeni, ara: مولبيدنيوم
 PWN:moment.n.01		chana	chana	hin:क्षण (kṣaṇ), tam:கணம் (kaṇam), zho:刹那 (chànà), yue:剎那 (saat3naa5), kor:찰나 (challa), vie:sát na, mya:ခဏ (khana), khm:ខណៈ (khaʼnaʼ), tha:ขณะ (khana)
@@ -1197,10 +1208,12 @@ PWN:neon.n.01		neon	neon	eng:neon, fra:néon, spa:neón, por:néon, rus:неон
 PWN:neptunium.n.01		neptunium	neptun·ium	eng:neptunium, fra:neptunium, spa:neptunio, por:neptúnio, rus:нептуний, zho:镎 (ná), jpn:ネプツニウム, kor:넵투늄, vie:neptuni, hin:नेप्ट्यूनियम, ben:নেপচুনিয়াম, may:neptunium, swa:neptuni, ara: نبتونيوم
 PWN:nerve.n.01		neuro	neur’o	eng:spa:por:fra:deu:neuro-, rus:невро- (nevro-)
 PWN:nest.n.01		nido	nido	eng:nest, spa:nido, por:ninho, fra:nid, rus:гнездо (gnezdo), hin:नीड़ (nīḍa), ben:নীড় (nīṛa)
+PWN:net.n.06		net	net	eng:net, deu:Netz
 PWN:never.r.01		no tem	no tem	
 PWN:new.a.01		nov	nov	eng:nov-, fra:nouveau, spa:nuevo, por:novo, rus:новый (novyy), hin:नव (nav), ben:নয় (nôy); নও- (nôo-), may:nawa
 PWN:news.n.01		habar	habar	ara: خَبَر‎ (xabar), fas: خبر‎ (xabar), hin:ख़बर (xabar), ben:খবর (khôbôr), tam:கபர் (kapar), may:kabar, tur:haber, swa:habari, hau:labari, yor:làbarè, ful:habaru
 PWN:nickel.n.01		nikel	nikel	eng:nickel, fra:nickel, spa:níquel, por:níquel, rus:никель, zho:镍 (niè), jpn:ニッケル, kor:니켈, vie:nikel, hin:निकेल, ben:নিকেল, may:nikel, swa:nikeli, ara: نيكل
+PWN:night.n.01		noche	noch'e	eng:nocturnal, por:noite, spa:noche, fra:noit, deu:Nacht
 PWN:nightingale.n.01		bulbul	bulbul	ara: بلبل‎ (bulbul), fas:(bolbol), hin:बुलबुल (bulbul), may:bulbul, tur:bülbül
 PWN:nine.s.01		nain	nain	eng:nine, deu:neun
 PWN:niobium.n.01		niobium	niob·ium	eng:niobium, fra:niobium, spa:niobio, por:nióbio, rus:ниобий, zho:铌 (ní), jpn:ニオブ, kor:나이오븀, vie:niobi, hin:नायोबियम, ben:নাইওবিয়াম, may:niobium, swa:niobi, ara: نيوبيوم
@@ -1237,6 +1250,7 @@ PWN:orange.s.01		aranje brun	aranj'e brun
 PWN:order.v.01		amir	amir	ara: أَمْر‎ (ʾamr), fas: امر‎ (amr), tur:emir, swa:amiri, hau:umarni, ful:amiiru + eng:admiral, fra:amiral, spa:por:emir rus:эмир (emir)
 PWN:organ.n.05		orgen	orgen	eng:may:organ, deu:Orgel, fra:orgue, spa:órgano, por:órgão, rus:орган (organ), fas: ارگ (org), hin:ऑर्गन (ŏrgan), tam:ஓர்கன் (ōrkaṉ), ara: أُرْغُن (ʔurḡun), tur:org, jpn:オルガン (orugan), kor:오르간 (oreugan), vie:oóc-gan
 PWN:organism.n.01		bioter	bio·ter	
+PWN:orientation.n.03		dika	dika	
 PWN:original.n.02		arketipe	ark·e.tip'e	
 PWN:original.n.02		idia	id·ia	eng:spa:idea, fra:idée, deu:Idee, por:ideia, rus:идея (ideya), may:ide, jpn:アイデア (aidea), kor:아이디어 (aidieo), vie:ý định
 PWN:original.s.01		aslik	asl·ik	
@@ -1419,6 +1433,7 @@ PWN:reach.v.04		kontakte	kon.takt'e
 PWN:real.a.01		hakik	hak·ik	
 PWN:reality.n.03		hakikia	hak·ik·ia	
 PWN:reasoning.n.01		ration	rat·ion	
+PWN:rectangle.n.01		retogon	ret·o·gon	
 PWN:red.s.01		rod	rod	eng:red, deu:rot, fra:rouge, spa:rojo, ita:rosso
 PWN:reflector.n.01		reflexer	re.flex·er	
 PWN:regulate.v.02		nome	nom'e	
@@ -1445,6 +1460,7 @@ PWN:revolve.v.01		rota	rota	eng:rotate, por:spa:rotar, rus:ро́тор (rótor)
 PWN:rhenium.n.01		renium	ren·ium	eng:rhenium, fra:rhénium, spa:renio, por:rénio, rus:рений, zho:铼 (lái), jpn:レニウム, kor:레늄, vie:reni, hin:रेनियम, ben:রেনিয়াম, may:renium, swa:reni, ara: رنيوم
 PWN:rhinal.a.01		nazal	naz·al	
 PWN:rhodium.n.01		rodium	rod·ium	eng:rhodium, fra:rhodium, spa:rodio, por:ródio, rus:родий, jpn:ロジウム, kor:로듐, vie:rođi, hin:रोडियम, ben:রোডিয়াম, may:rodium, swa:rodi, ara: روديوم
+PWN:rhumb_line.n.01		simgon line	sim·gon lin'e	
 PWN:right.a.01		dexe	dex'e	
 PWN:right.n.01		hak	hak	ara: حَقّ‎ (ḥaqq), hin:हक़ (haq), ben:হক (hôk), pnb:ਹੱਕ (hakka), tel:హక్కు (hakku), tur:may:hak, swa:haki, hau:hakki, ful:haƙƙe
 PWN:ring.n.08		ring	ring	
@@ -1456,6 +1472,7 @@ PWN:roentgenium.n.01		rentgenium	rentgen·ium	eng:roentgenium, fra:roentgenium, 
 PWN:roof.n.01		chati	chati	hin:छत (chat); छदि (chadi), ben: ছাদ (chad), tur:çatı, kyr:чатыр (čatyr) + ara: سَطْح‎ (saṭḥ)
 PWN:room.n.01		kamre	kamr'e	may:kamar, por:câmara, hin:कमरा, (kamrā), deu:Kammer, rus:камера (kamera)
 PWN:rose_apple.n.02		jambu	jambu	hin:जामुन (jāmun), eng:jambul, por:jambolão, ara:جَمُّون (jammūn), swa:zambarau, zho:閻浮 (yánfú)
+PWN:rotation.n.01		rotation	rota·tion	
 PWN:rotten.s.03		futre	futr'e	eng:putrid, fra:pourri; putride, spa:por:podre + may:buruk + zho:腐 (fǔ), yue:腐 (fu6), jpn:腐 (fu) + tha:ผุ (phu)
 PWN:rubber.n.01		gom	gom	fra:gomme, spa:tgl:goma, jpn:ゴム (gomu), kor:고무 (gomu) + eng:gum, deu:Gummi + hin:गम (gam), ben:গাম (gam)
 PWN:rubidium.n.01		rubium	rub·ium	eng:rubidium, fra:rubidium, spa:rubidio, por:rubídio, rus:рубидий, zho:铷 (rú), jpn:ルビジウム, kor:루비듐, vie:rubiđi, hin:रुबिडियम, ben:রুবিডিয়াম, may:rubidium, swa:rubidi, ara: روبيديوم
@@ -1499,6 +1516,7 @@ PWN:seed.n.02		sem	sem	fra:semence, por:semente, spa:semilla, rus:семя (semy
 PWN:selenium.n.01		selenium	selen·ium	eng:selenium, fra:sélénium, spa:selenio, por:selénio, rus:селен, zho:硒 (xī), jpn:セレン, kor:셀렌, vie:selen, hin:सेलेनियम, ben:সেলেনিয়াম, may:selenium, swa:seleni, ara: سيلينيوم
 PWN:semaphore.n.01		semafer	sema·fer	
 PWN:send.v.01		mis	mis	eng:emit, fra:émettre, spa:por:remitir, may:emisi, deu:Mission, rus:миссия (missiya), tur:misyon + hin:कमीशन (kamīśan), ben:কমিশন (kômiśôn)
+PWN:sepia.n.02		sepia	sepia	eng:spa:map:sepia, por:sépia, rus:се́пия (sépija), tur:sepya, hin:सीपिया (sīpiya), jpn:セピア (sepia)	
 PWN:september.n.01		mes nain	mes nain	
 PWN:series.n.01		seria	ser·ia	
 PWN:servant.n.01		server	serv·er	
@@ -1541,6 +1559,7 @@ PWN:sing.v.02		gante	gant'e	spa:por:cantar, ara: غَنَّى‎ (ḡannā), hin
 PWN:sister.n.01		sis	sis	eng:sister, deu:Schwester, rus:сестра (sestra)
 PWN:sit.v.01		sid	sid	
 PWN:six.s.01		sixe	six'e	eng:fra:six, deu:sechs, spa:por:seis + ara: سِتَّة‎ (sitta), hau:shida, swa:sita
+PWN:size.n.01		daita	dai·ta	
 PWN:ski.n.01		ski	ski	eng:fra:ski, deu:Ski, spa:esquí, por:esqui, hin:स्की (skī), ben:স্কী (ski), jpn:スキー (sukī), kor:스키 (seuki)
 PWN:skill.n.01		sut	sut	zho:术 (shù), yue:術 (seot6), jpn:術 (jutsu), kor:술 (sul), vie:thuật
 PWN:skull.n.01		kaposte	kap·ost'e	
@@ -1576,6 +1595,8 @@ PWN:source_code.n.01		asle kod	asl'e kod
 PWN:south.n.03		sud	sud	deu:Süden, fra:sud, spa:sur, por:sul, eng:south, rus:зюйд (zyuyd)
 PWN:space.n.01		kosme	kosm'e	eng:fra:spa:cosmos, deu:Kosmos, por:cosmo, rus:космос (kosmos), tur:kozmo-
 PWN:spain.n.01		Espania	Espan·ia	
+PWN:spanish.a.01		hispane	hispan'e	
+PWN:spell.v.01		kitab	kitab	
 PWN:spider.n.01		aran	aran	fra:araignee, por:aranha, spa:araña, eng:arachnid, deu:Arachno-, rus:арахнофо- (arakhno-), tur:arakno-, tam:அராக்கினிட் (arākkiṉiṭ), may:araknid
 PWN:spin.v.01		rota	rota	
 PWN:spinach.n.01		spanak	spanak	
@@ -1683,6 +1704,7 @@ PWN:tepee.n.01		tipi	tipi	deu:Tipi, eng:fra:spa:por:may:tur:tipi, hin:टीप�
 PWN:terbium.n.01		terbium	terb·ium	eng:terbium, fra:terbium, spa:terbio, por:térbio, rus:тербий, zho:铽 (tè), jpn:テルビウム, kor:테르븀, 2터븀, vie:tecbi, hin:टर्बियम, ben:টার্বিয়াম, may:terbium, swa:taribi, ara: تربيوم
 PWN:tesla.n.01		tesla	tesla	
 PWN:test.v.01		teste	test'e	eng:test, por:teste, spa:test, rus:тест (test), tur:test, fas:تست (test), jpn:テスト (tesuto)
+PWN:texture.n.01		taktur	takt·ur	
 PWN:thallium.n.01		talium	tal·ium	eng:thallium, fra:thallium, spa:talio, por:tálio, rus:таллий, zho:铊 (tā), jpn:タリウム, kor:탈륨, vie:tali, hin:थैलियम, ben:থ্যালিয়াম, may:tallium, swa:tali, ara: ثاليوم
 PWN:thank.v.01		danke	dank'e	eng:thank, deu:danken, pol:dziękować, ukr:дякувати (dyakuvati), hin:थैंक्स (tha͠iks), zho:三Q (sān kiù), jpn:サンキュー (sankyū), kor:땡큐 (ttaengkyu)
 PWN:theism.n.01		deisme	de·ism'e	
@@ -1775,6 +1797,7 @@ PWN:ununquadium.n.01		flerovium	flerov·ium	eng:may:flerovium, fra:flérovium, s
 PWN:ununtrium.n.01		niponium	nipon·ium	eng:fra:may:nihonium, spa:nihonio, por:nihonium, rus:нихоний, jpn:ニホニウム, kor:우눈트륨, vie:swa:nihoni
 PWN:unwind.v.01		devolu	de.volu	
 PWN:update.v.02		novifa	nov·ifa	
+PWN:upload.v.01		kargo	kargo	
 PWN:uranium.n.01		uranium	uran·ium	eng:uranium, fra:uranium, spa:uranio, por:urânio, rus:уран, jpn:ウラン, kor:우라늄, vie:urani (uran), hin:युरेनियम, ben:ইউরেনিয়াম, may:uranium, swa:urani, ara: يورانيوم
 PWN:urban.a.01		polik	pol·ik	
 PWN:urine.n.01		pisha	pisha	eng:piss, deu:Pisse, fra:pisse, fas:پیشاب (pišâb), hin:पेशाब (pešāb), ben:পেশাব (peśab), may:pipis
@@ -1804,6 +1827,7 @@ PWN:water.n.06		sui	sui	zho:水 (shuǐ), yue:水 (seoi2), jpn:水 (sui), kor:수
 PWN:watermelon.n.01		arbuz	arbuz	rus:арбуз (arbuz), pol:arbuz, tur:karpuz, fas: تربز (tarboz), hin:तरबूज़ (tarbūz), ben:তরমুজ (tôrmuj), tam:தர்பூசணி (tarpūcaṇi)
 PWN:wax.n.01		mum	mum	hin:मोम (mom), ben:মোম (mom), fas: موم‎ (mum), tur:mum + ara: مومياء (mumiya), eng:mummy, fra:momie, spa:momia, por:múmia, rus:мумия (mumiya), zho:木乃伊 (mùnǎiyī), may:mumia
 PWN:way.n.06		vei	vei	
+PWN:web.n.01		net	net	
 PWN:web_log.n.01		blog	blog	eng:fra:spa:por:tur:may:blog, rus:блог (blog), ara:بلوغ‎ (blūḡ), hin:ब्लॉग (blŏg), zho:博客 (bókè), jpn:ブログ (burogu)
 PWN:west.n.02		veste	vest'e	eng:west, deu:West, fra:ouest, spa:por:oeste, rus:вест (vest)
 PWN:wet.a.01		nem	nem	fas: نم‎ (nam), hin:नम (nam), ben:নম (nom), tur:nem, vie:ẩm
@@ -1812,6 +1836,8 @@ PWN:wheat.n.01		gandum	gandum	fas:گندم‎(gandom), hin:गोधूम (godh
 PWN:whiskey.n.01		viski	viski	
 PWN:white.a.01		vait	vait	eng:white, deu:weiß
 PWN:whole.a.01		hol	hol	eng:whole; all; holo-, deu:fra:spa:por:holo-, rus:голо- (golo-); хол- (hol-), jpn:ホログ- (holo-), kor:홀로- (hollo-) + ara: كُلّ‎ (kull)
+PWN:wide.a.01		chaure	chaur'e	hin:चौड़ा  (cauṛā), ben:, pan:চওড়া (coōṛa), ਚੌੜਾ (cauṛā)
+PWN:width.n.01		chaurita	chaur·ita	
 PWN:wind.n.01		vante	vant’e	eng:wind, deu:Wind, fra:vent, spa:viento, por:vento, rus:ветер (veter), fas: باد (bâd), hin:वात (vāt), ben:বাতাস (bataś), tam:(vāṭai), tel:వాతము (vātamu), may:badai✱
 PWN:wind.v.03		volu	volu	
 PWN:wine.n.01		vain	vain	fra:vin, spa:vino, por:vinho, rus:вино (vino), eng:wine, deu:Wein, hin:वाइन (vāin), tam:வைன் (vaiṉ), may:wain, swa:divai, jpn:ワイン (wain), kor:와인 (wain), vie:vang


### PR DESCRIPTION
this commit adds the new Pandunia words _sepia_ ('sepia'), _kontenet_ ('content'), _kenar_ ('border'), _retogon_ ('rectangle'), _retogonia_* ('grid'), _net_ ('net' or 'web'), _simgon line_ ('rhumb line'), _dekargo_ (download), _busola_ ('compass, as used to find direction'), _pergar_ ('compass, as used to draw circles'), _fokus_ ('focus'), _daita_ ('size'), _chaure_ ('wide'), _chaurita_ ('width'), _taktur_ ('texture'), _rotation_ ('rotation'), _hispane_ ('Spanish'), _latine_ ('Latin'), _novostil_ ('modern'), and _laostil_ ('old-fashioned').

it also adds new meanings to the Pandunia words _kargo_ ('upload'), _dika_ ('orientation'), and _kitab_ ('spell').

it also adds the following Pandunia words that were on the website or alluded to in compound words but not themselves in the dictionary: _noche_ ('night'), _english_ ('English'), and _rus_ ('Russian').

*as far as I know there are no words that currently use the _-ia_ suffix quite like this, but it seems similar to the way you combine many _nes_ to form a _nesia_, or combine many _homan_ to form _homania_ – you combine many rectangles to form a grid.